### PR TITLE
Add "Make KePub font sizes match ePub font sizes" option

### DIFF
--- a/src/versions/4.10.11591/libnickel.so.1.0.0.yaml/geoffr.yaml
+++ b/src/versions/4.10.11591/libnickel.so.1.0.0.yaml/geoffr.yaml
@@ -658,6 +658,10 @@ KePub stylesheet additions:
     # Example 3: text-rendering:optimizeLegibility: Enables ligatures, but causes
     # some additional rendering problems for fully justified text.
 # - ReplaceString: {Offset: 0x023B, Find: "/*********************************************/", Replace: "body{text-rendering:optimizeLegibility        }"}
+    #
+    # Example 4: Make KePub font sizes match ePub font sizes: ePubs render with
+    # 1.5 times the font size of KePubs by default. With this enabled they match.
+# - ReplaceString: {Offset: 0x023B, Find: "/*********************************************/", Replace: "#book-inner{font-size:1.5em                   }"}
 
 Change dicthtml strings to micthtml:
   - Enabled: no

--- a/src/versions/4.10.11655/libnickel.so.1.0.0.yaml/geoffr.yaml
+++ b/src/versions/4.10.11655/libnickel.so.1.0.0.yaml/geoffr.yaml
@@ -659,6 +659,10 @@ KePub stylesheet additions:
     # Example 3: text-rendering:optimizeLegibility: Enables ligatures, but causes
     # some additional rendering problems for fully justified text.
 # - ReplaceString: {Offset: 0x023B, Find: "/*********************************************/", Replace: "body{text-rendering:optimizeLegibility        }"}
+    #
+    # Example 4: Make KePub font sizes match ePub font sizes: ePubs render with
+    # 1.5 times the font size of KePubs by default. With this enabled they match.
+# - ReplaceString: {Offset: 0x023B, Find: "/*********************************************/", Replace: "#book-inner{font-size:1.5em                   }"}
 
 Change dicthtml strings to micthtml:
   - Enabled: no

--- a/src/versions/4.9.11311/libnickel.so.1.0.0.yaml/geoffr.yaml
+++ b/src/versions/4.9.11311/libnickel.so.1.0.0.yaml/geoffr.yaml
@@ -659,6 +659,10 @@ KePub stylesheet additions:
     # Example 3: text-rendering:optimizeLegibility: Enables ligatures, but causes
     # some additional rendering problems for fully justified text.
 # - ReplaceString: {Offset: 0x023B, Find: "/*********************************************/", Replace: "body{text-rendering:optimizeLegibility        }"}
+    #
+    # Example 4: Make KePub font sizes match ePub font sizes: ePubs render with
+    # 1.5 times the font size of KePubs by default. With this enabled they match.
+# - ReplaceString: {Offset: 0x023B, Find: "/*********************************************/", Replace: "#book-inner{font-size:1.5em                   }"}
 
 Change dicthtml strings to micthtml:
   - Enabled: no

--- a/src/versions/4.9.11314/libnickel.so.1.0.0.yaml/geoffr.yaml
+++ b/src/versions/4.9.11314/libnickel.so.1.0.0.yaml/geoffr.yaml
@@ -659,6 +659,10 @@ KePub stylesheet additions:
     # Example 3: text-rendering:optimizeLegibility: Enables ligatures, but causes
     # some additional rendering problems for fully justified text.
 # - ReplaceString: {Offset: 0x023B, Find: "/*********************************************/", Replace: "body{text-rendering:optimizeLegibility        }"}
+    #
+    # Example 4: Make KePub font sizes match ePub font sizes: ePubs render with
+    # 1.5 times the font size of KePubs by default. With this enabled they match.
+# - ReplaceString: {Offset: 0x023B, Find: "/*********************************************/", Replace: "#book-inner{font-size:1.5em                   }"}
 
 Change dicthtml strings to micthtml:
   - Enabled: no


### PR DESCRIPTION
This adds a fourth example to the "KePub stylesheet additions" patch, intended to equalise the KePub font size to that of the ePub renderer.

This is [a recreation of a patch I developed in 2017](https://www.mobileread.com/forums/showpost.php?p=3576688&postcount=206) which required a similar shrinking of CSS (it used the link CSS instead, but it does the same job!)

I’ve actually tested on firmware 4.8.11073 (I overrode the version number, and updated the patches I wanted to use to match those in the other patcher for that firmware - is there any chance you’d accept patch backports, given this is the latest firmware for many devices?) and confirmed the font sizes line up according to an ePub and KePub copy of “[ePub Feature Peeker](https://www.mobileread.com/forums/showthread.php?t=211123)”