### PR TITLE
SmartLink patches (closes #10)

### DIFF
--- a/src/versions/4.12.12111/libnickel.so.1.0.0.yaml/geek1011.yaml
+++ b/src/versions/4.12.12111/libnickel.so.1.0.0.yaml/geek1011.yaml
@@ -214,3 +214,16 @@ Only show stats SmartLink:
   # in SmartLinkWidget::showRotationMessage:
   # change the result of the call to ActivityManager::smartLinkGeneralMessage to 15 (0x0F):
   - ReplaceBytes: {Offset: 0x8DBA68, FindBLX: 0x42744C, ReplaceH: 4F F0 0F 00}
+
+Never show Kobo Plus, wishlist, and points SmartLinks:
+  - Enabled: no
+  - PatchGroup: SmartLink
+  - Description: |
+      Removes Kobo Plus, wishlist, and points SmartLinks from the rotation.
+  # in ActivityManager::smartLinkGeneralMessage(ActivityManager *this, const Device *a2):
+  # NOP Kobo Plus (2):
+  - ReplaceBytesNOP: {Offset: 0x5BACAA, FindBLX: 0x405110}
+  # NOP wishlist (13):
+  - ReplaceBytesNOP: {Offset: 0x5BABFC, FindBLX: 0x405110}
+  # NOP super points (16):
+  - ReplaceBytesNOP: {Offset: 0x5BAE34, FindBLX: 0x405110}

--- a/src/versions/4.12.12111/libnickel.so.1.0.0.yaml/geek1011.yaml
+++ b/src/versions/4.12.12111/libnickel.so.1.0.0.yaml/geek1011.yaml
@@ -160,3 +160,39 @@ Disable all tutorial dialogs:
   - ReplaceBytesAtSymbol: {Symbol: "ApplicationSettings::syncReminderDialogShown()",        Offset: 53, FindBLX: 0x400fd8, ReplaceH: 4F F0 01 00}
   - ReplaceBytesAtSymbol: {Symbol: "ApplicationSettings::eReaderBooksManagementFTEShown()", Offset: 53, FindBLX: 0x400fd8, ReplaceH: 4F F0 01 00}
   - ReplaceBytesAtSymbol: {Symbol: "ApplicationSettings::libraryCuratedListsDialogShown()", Offset: 53, FindBLX: 0x400fd8, ReplaceH: 4F F0 01 00}
+
+Set visible SmartLink:
+  - Enabled: no
+  - PatchGroup: SmartLink
+  - Description: |
+      Sets the currently visible smartlink (does not override priority messages).
+  # SmartLinks: (name from SmartLinkWidget::getAnalyticsMessage)
+  #  # - internal name   - default condition                                   - what                                                             - action
+  # PRIORITY MESSAGES (shown first up to 3 times each): (SmartLinkWidget::showPriorityMessage, ActivityManager::smartLinkPriorityMessage, SmartLinkWidget::tapped)
+  #  5 - ReleaseNotes    - whats new available from Activity                   - RELEASE NOTES: Find out what's new in this software update       - whats new (from Activity)
+  #  6 - OverdriveFTE    - overdrive enabled && not signed in                  - OVERDRIVE: Learn how to borrow eBooks from your public library   - overdrive about
+  #  7 - KoboPlusFTE     - kobo plus enabled && not subscribed                 - KOBO PLUS: Browse Kobo Plus books                                - kobo store -> kobo plus
+  # ROTATION MESSAGES (randomly chosen): (SmartLinkWidget::showRotationMessage, ActivityManager::smartLinkGeneralMessage, SmartLinkWidget::tapped)
+  #  1 - Pocket          - pocket not signed in                                - POCKET: Read articles from the web on your eReader               - pocket about
+  #  2 - KoboPlus        - kobo plus enabled && not subscribed                 - KOBO PLUS: Get unlimited access to books in all genres           - kobo store -> kobo plus
+  #  2 - KoboPlus        - kobo plus enabled && not subscribed                 - KOBO PLUS: Read as much as you want with our ebook subscription  - kobo store -> kobo plus
+  #  3 - Overdrive       - overdrive enabled && not signed in                  - OVERDRIVE: Borrow eBooks from your public library                - overdrive about
+  #  4 - Categories      - always                                              - CATEGORIES: Browse fiction, romance, biography and more          - kobo store -> categories
+  #  8 - NaturalLight    - has light sensor && not viewed tutorial             - DEVICE NAME: Learn about the Natural Light feature               - rgb front light about
+  #  9 - QuickTour       - quick tour not shown && quick turn tile not visible - GETTING STARTED: Get to know your %0                             - quick tour
+  # 10 - ReadingTour     - read a book tour not showed                         - READING A BOOK: Get quick tips about reading on your eReader     - read a book tutorial
+  # 11 - UserGuide       - user guide present && not opened                    - USER GUIDE: Read the user guide for your %0                      - read -> user guide
+  # 12 - RelatedReads    - recent book available from Activity                 - RELATED READS: Discover books related to the ones you're reading - browse -> similar books
+  # 13 - Wishlist        - no wishlist items || something else                 - WISHLIST: Create a Wishlist of books you're interested in        - browse -> wishlist
+  # 14 - ReadingSettings - reading settings not changed                        - READING SETTINGS: Customize the way you read a book              - settings -> reading settings
+  # 15 - ReadingStats    - books finished > 0 && hours read rounded to .5 > 0  - READING STATS: You've finished %n books and read for %n hours    - reading life -> stats
+  # 16 - SuperPoints     - participating in super points && points > 2400      - KOBO SUPER POINTS: You have %0 Super Points to redeem            - kobo store
+  # 17 - PocketUser      - unread pocket articles > 0                          - POCKET: Catch up on the %n article(s) you added recently         - library -> pocket
+  #
+  # in SmartLinkWidget::showRotationMessage, which is the only caller of ActivityManager::smartLinkGeneralMessage:
+  # change the result of the call to ActivityManager::smartLinkGeneralMessage:
+  - ReplaceBytes: {Offset: 0x8DBA68, FindBLX: 0x42744C, ReplaceH: 4F F0 04 00}
+  # set the new SmartLink to show (you can set this to your preference based on the
+  # previous list, but it MUST be one of the above options, or you may need to
+  # factory reset):
+  - ReplaceInt: {Offset: 0x8DBA6A, Find: 4, Replace: 4}

--- a/src/versions/4.12.12111/libnickel.so.1.0.0.yaml/geek1011.yaml
+++ b/src/versions/4.12.12111/libnickel.so.1.0.0.yaml/geek1011.yaml
@@ -205,6 +205,9 @@ Only show Pocket SmartLink:
   # in SmartLinkWidget::showRotationMessage:
   # change the result of the call to ActivityManager::smartLinkGeneralMessage to 17 (0x11):
   - ReplaceBytes: {Offset: 0x8DBA68, FindBLX: 0x42744C, ReplaceH: 4F F0 11 00}
+  # replace the text:
+  - FindReplaceString: {Find: "Catch up on the %n article(s) you added recently", Replace: "My Articles"}
+# - FindReplaceString: {Find: "Catch up on the %n article(s) you added recently", Replace: "My Articles (%n unread)"}
 
 Only show stats SmartLink:
   - Enabled: no

--- a/src/versions/4.12.12111/libnickel.so.1.0.0.yaml/geek1011.yaml
+++ b/src/versions/4.12.12111/libnickel.so.1.0.0.yaml/geek1011.yaml
@@ -205,3 +205,12 @@ Only show Pocket SmartLink:
   # in SmartLinkWidget::showRotationMessage:
   # change the result of the call to ActivityManager::smartLinkGeneralMessage to 17 (0x11):
   - ReplaceBytes: {Offset: 0x8DBA68, FindBLX: 0x42744C, ReplaceH: 4F F0 11 00}
+
+Only show stats SmartLink:
+  - Enabled: no
+  - PatchGroup: SmartLink
+  - Description: |
+      Only show the stats SmartLink on the home screen.
+  # in SmartLinkWidget::showRotationMessage:
+  # change the result of the call to ActivityManager::smartLinkGeneralMessage to 15 (0x0F):
+  - ReplaceBytes: {Offset: 0x8DBA68, FindBLX: 0x42744C, ReplaceH: 4F F0 0F 00}

--- a/src/versions/4.12.12111/libnickel.so.1.0.0.yaml/geek1011.yaml
+++ b/src/versions/4.12.12111/libnickel.so.1.0.0.yaml/geek1011.yaml
@@ -196,3 +196,12 @@ Set visible SmartLink:
   # previous list, but it MUST be one of the above options, or you may need to
   # factory reset):
   - ReplaceInt: {Offset: 0x8DBA6A, Find: 4, Replace: 4}
+
+Only show Pocket SmartLink:
+  - Enabled: no
+  - PatchGroup: SmartLink
+  - Description: |
+      Only show the Pocket SmartLink on the home screen.
+  # in SmartLinkWidget::showRotationMessage:
+  # change the result of the call to ActivityManager::smartLinkGeneralMessage to 17 (0x11):
+  - ReplaceBytes: {Offset: 0x8DBA68, FindBLX: 0x42744C, ReplaceH: 4F F0 11 00}


### PR DESCRIPTION
Add 4 new SmartLink patches:

- Set visible SmartLink
- Only show pocket
- Only show stats
- Never show Kobo Plus, wishlist, and points SmartLinks

closes #10