### PR TITLE
Fix the 'Block WiFi firmware' on 4.38.21908

### DIFF
--- a/src/versions/4.38.21908/libnickel.so.1.0.0.yaml/geoffr.yaml
+++ b/src/versions/4.38.21908/libnickel.so.1.0.0.yaml/geoffr.yaml
@@ -290,6 +290,9 @@ Block WiFi firmware upgrade:
   - FindReplaceString:
       Find:    "UpgradeCheck/%1/%2/%3/%4/%5"
       Replace: "UpgradeCheck/%1/%2/k/99.9/5"
+  - FindReplaceString:
+      Find: "https://api.kobobooks.com/1.0/UpgradeCheck/%1/%2/%3/%4/%5"
+      Replace: "https://api.kobobooks.com/1.0/UpgradeCheck/%1/%2/k/99.9/5"
 
 Custom Sleep/Power-off timeouts:
   - Enabled: no


### PR DESCRIPTION
The `Block WiFi firmware upgrade` was broken, this change fix it.

## Why ?

I want to avoid the 4.38.23038 firmware on my Libra 2 and Clara 2E since the patches for that version has not been released yet. I was tired of getting the update popup.

## How ?

Kobo appears to be using the patched firmware upgrade procedure as a fallback method (as proven by the name of the method `getBackupUpgradeUrlEv`) and is now using `getUpgradeServiceUrlEv` which contains another similar upgrade check url as the previous one. This change patches both methods.

## Prove it

I can't post screenshots for obvious copyright issues, but you can search the above methods by disassembling `libnickel.so.1.0.0` like I did to verify my work. I used Hopper Disassembler for my investigations.

## Thou shalt test

I tested it on my Libra 2 and Clara 2E running firmware 4.38.21908. Both bypass the 4.38.23038 firmware and still sync. It is also working using a CalibreWeb backend.