### PR TITLE
Update for 4.40.23081

### DIFF
--- a/src/versions/4.40.23081/libadobe.so.yaml/pgaskin.yaml
+++ b/src/versions/4.40.23081/libadobe.so.yaml/pgaskin.yaml
@@ -1,0 +1,10 @@
+# The following patch(es) were fixed and are updated by pgaskin (geek1011)
+
+Remove PDF map widget shown during panning:
+  - Enabled: no
+  - Description: Removes the PDF map widget shown during panning and zooming.
+  - BaseAddress:  {Sym: "N3AdobeReader::showMapWidget()"}
+  # tail: N3AdobeReader::updatePanningMap() -> N3AdobeReader::hideMapWidget()
+  # TODO: figure out what broke the plt parsing in kobopatch for libadobe in 18730+
+  - ReplaceBytes: {Offset:  80, FindInstBW: 0x1C388, ReplaceInstBW: 0x1B650}
+  - ReplaceBytes: {Offset: 192, FindInstBW: 0x1C388, ReplaceInstBW: 0x1B650}

--- a/src/versions/4.40.23081/libnickel.so.1.0.0.yaml/geoffr.yaml
+++ b/src/versions/4.40.23081/libnickel.so.1.0.0.yaml/geoffr.yaml
@@ -1,0 +1,354 @@
+# The following patch(es) were made by GeoffR, and most are updated by pgaskin (geek1011)
+
+# The next 2 patches are alternatives.
+# Beware that the KePub reader has problems with its page break position
+# when narrow line spacings are selected, depending on which font is used.
+# You can increase the replace_float values at the bottom of each patch to
+# avoid those problems, or else simply refrain from selecting narrowest
+# line spacings when reading KePubs.
+
+My 10 line spacing values:
+  - Enabled: no
+  - PatchGroup: Line spacing values alternatives
+  - Description: |
+      This patch changes the values on the line spacing adjustment slider,
+      reducing the number of spacing options from 15 to 10, but allowing
+      much narrower spacing values to be set.
+    # Bypass code-constructed values 1.0, 1.2, 1.5, 2.0, 3.0
+    # These are all the appends not loaded using adr.
+  - BaseAddress:  {Sym: "ReadingSettings::lineHeightScalars() const", Rel: 84} # first append
+  - ReplaceBytes: {Offset:   0, FindInstBLX: {SymPLT: "QList<double>::append(double const&)"}, ReplaceInstNOP: true}
+  - ReplaceBytes: {Offset:  86, FindInstBLX: {SymPLT: "QList<double>::append(double const&)"}, ReplaceInstNOP: true}
+  - ReplaceBytes: {Offset: 128, FindInstBLX: {SymPLT: "QList<double>::append(double const&)"}, ReplaceInstNOP: true}
+  - ReplaceBytes: {Offset: 188, FindInstBLX: {SymPLT: "QList<double>::append(double const&)"}, ReplaceInstNOP: true}
+  - ReplaceBytes: {Offset: 290, FindInstBLX: {SymPLT: "QList<double>::append(double const&)"}, ReplaceInstNOP: true}
+    # 10 values for replacement, change these replace_float values to suit:
+    # Find the prologue for the values + first subtraction (has been unique in
+    # every version so far, and is near impossible to change and fail silently):
+  - FindBaseAddressHex: CDCC CCCC CCCC F03F 1F85
+  - ReplaceFloat: {Offset: 0x00,  Find: 1.05, Replace: 0.8}
+  - ReplaceFloat: {Offset: 0x08,  Find: 1.07, Replace: 0.85}
+  - ReplaceFloat: {Offset: 0x10,  Find: 1.1,  Replace: 0.875}
+  - ReplaceFloat: {Offset: 0x18,  Find: 1.35, Replace: 0.9}
+  - ReplaceFloat: {Offset: 0x20,  Find: 1.7,  Replace: 0.925}
+  - ReplaceFloat: {Offset: 0x28,  Find: 1.8,  Replace: 0.95}
+  - ReplaceFloat: {Offset: 0x30,  Find: 2.2,  Replace: 0.975}
+  - ReplaceFloat: {Offset: 0x38,  Find: 2.4,  Replace: 1.0}
+  - ReplaceFloat: {Offset: 0x40,  Find: 2.6,  Replace: 1.05}
+  - ReplaceFloat: {Offset: 0x48,  Find: 2.8,  Replace: 1.1}
+
+# TODO(geek1011): My 24 line spacing values
+
+Custom left & right margins:
+  - Enabled: no
+  - Description: |
+      This patch sets the size of the margins added by the margins
+      adjustment slider, as a percentage of screen width.
+  - FindBaseAddressString: "\0\0\0\0\x02\0\0\0\x04\0\0\0\x06\0\0\0\x08\0\0\0\x0A\0\0\0\x0C\0\0\0\x0E\0\0\0\x10\0\0\0"
+  # 9 values for replacement:
+  - ReplaceInt: {Offset: 0x00, Find:  0, Replace: 0}
+  - ReplaceInt: {Offset: 0x04, Find:  2, Replace: 1}
+  - ReplaceInt: {Offset: 0x08, Find:  4, Replace: 2}
+  - ReplaceInt: {Offset: 0x0C, Find:  6, Replace: 3}
+  - ReplaceInt: {Offset: 0x10, Find:  8, Replace: 4}
+  - ReplaceInt: {Offset: 0x14, Find: 10, Replace: 5}
+  - ReplaceInt: {Offset: 0x18, Find: 12, Replace: 6}
+  - ReplaceInt: {Offset: 0x1C, Find: 14, Replace: 7}
+  - ReplaceInt: {Offset: 0x20, Find: 16, Replace: 8}
+
+Custom font sizes:
+  - Enabled: no
+  - Description: |
+      Changes the range of sizes on the font size slider so that there are more of
+      the small sizes and fewer of the large sizes.
+      With this patch enabled you will not be able to select the very large font
+      sizes, but will be able to make finer adjustment to the smaller sizes.
+  # Font sizes depend on the device's screen density. Unpatched, the sizes
+  # increase in steps of 1 from the smallest size up to size 44, then in steps
+  # of 2 up to size 68, then in steps of 4 up to the largest size:
+  #
+  #                     Touch/Mini:    8px -  90px  (39 steps)
+  #          AuraHD/AuraH2O/Libra2:    8px - 150px  (54 steps)
+  #                  GloHD/ClaraHD:   10px - 150px  (52 steps)
+  #                       LibraH2O:   11px - 150px  (51 steps)
+  #      AuraOne/Forma/Elipsa/Sage:   14px - 195px  (59 steps)
+  #                   Aura/Glo/Nia:    8px - 122px  (47 steps)
+  #
+  # The example replacement values in this patch result in the following ranges,
+  # with increases in steps of 1 from the smallest size up to size 44, then
+  # steps of 2 up to size 68, then steps of 4 up to the largest size:
+  #
+  #                     Touch/Mini:    8px -  80px  (52 steps)
+  #          AuraHD/AuraH2O/Libra2:    8px - 108px  (59 steps)
+  #                  GloHD/ClaraHD:   10px - 108px  (57 steps)
+  #                       LibraH2O:   11px - 108px  (56 steps)
+  #      AuraOne/Forma/Elipsa/Sage:   14px - 132px  (59 steps)
+  #                   Aura/Glo/Nia:    8px -  88px  (54 steps)
+  #
+  # Note (pgaskin): The device values can be determined with info from
+  #    https://gist.github.com/pgaskin/613b34c23f026f7c39c50ee32f5e167e and
+  #    the Device::is* calls.
+  #
+  # This patch was rewritten for 18220 by @shermp.
+  #
+  - BaseAddress: "N3FontTypeUtil::fontSizes()"
+  # Initial font size:
+  - ReplaceInt: {Offset:  378, Find:   8, Replace:   8} # Other devices
+  - ReplaceInt: {Offset:  374, Find:  11, Replace:  11} # LibraH2O (storm)
+  - ReplaceInt: {Offset:   36, Find:  10, Replace:  10} # GloHD/ClaraHD (alyssum nova)
+  - ReplaceInt: {Offset:  404, Find:  14, Replace:  14} # Forma/AuraOne/Sage/Elipsa (daylight)
+  # Increment:
+  - ReplaceInt: {Offset:  222, Find:  21, Replace:  43} # Add font sizes in increments of 1 until this size exceeded
+  - ReplaceInt: {Offset:  228, Find:  22, Replace:  44} # Continue from this font size
+  - ReplaceInt: {Offset:  250, Find:  49, Replace:  67} # Add font sizes in increments of 2 until this size exceeded
+  - ReplaceInt: {Offset:  256, Find:  50, Replace:  68} # Continue from this font size
+  # Now increment by +4 until final font size:
+  - ReplaceInt: {Offset:  420, Find:   90, Replace:   80} # Other devices
+  - ReplaceInt: {Offset:  422, Find:  122, Replace:   88} # Aura/Glo/Nia (phoenix)
+  - ReplaceInt: {Offset:   48, Find:  150, Replace:  108} # LibraH2O/AuraHD/ClaraHD/GloHD/AuraH2O/Libra2 (dragon)
+  - ReplaceInt: {Offset:  400, Find:  195, Replace:  132} # Forma/AuraOne/Sage/Elipsa (daylight)
+
+ePub fixed top/bottom margins:
+  - Enabled: no
+  - PatchGroup: ePub padding-bottom alternatives
+  - Description:
+      This patch sets the @page margin sizes in epubs to fixed custom values,
+      overriding any @page margin set in the book's CSS stylesheet. (But beware
+      that some books also set page margins in an XPGT stylesheet which are added
+      to any CSS @page margins, and those will not be affected by this patch).
+    #      padding-bottom: %1em !important;\n
+    # --> }@page{margin:00px 00px 00px}body{
+  - FindReplaceString:
+      Find: "\x20padding-bottom: %1em !important;\n"
+      Replace: "}@page{margin:00px 00px 00px}body{"
+    # *** Replacement values start here, don't change anything above ***
+  - ReplaceString: {Offset: 0x0E, Find: "00px", Replace: "00px", MustMatchLength: yes} # TOP MARGIN: Replacement value is the margin size (two digits) in pixels:
+  - ReplaceString: {Offset: 0x18, Find: "00px", Replace: "00px", MustMatchLength: yes} # BOTTOM MARGIN: Replacement value is the margin size (two digits) in pixels:
+    #
+    # Minimum LEFT/RIGHT MARGIN: (This margin will overlap the left/right margin
+    # set with the adjustment slider, not add to it.) Replacement value is margin
+    # size (two digits) in pixels:
+  - ReplaceString: {Offset: 0x13, Find: "00px", Replace: "00px", MustMatchLength: yes}
+
+ePub disable built-in body padding-bottom:
+  - Enabled: no
+  - PatchGroup: ePub padding-bottom alternatives
+  - Description: |
+      The built-in ePub stylesheet adds a line of padding at the bottom of the
+      body element, to prevent the chapter ending on the last line of a page.
+      This patch disables that stylesheet entry.
+
+      This patch is not compatible with `ePub fixed/adjustable top/bottom margins`
+      patch, which already removes this stylesheet entry to make room for other
+      things.
+    #      padding-bottom: %1em !important;\n
+    # -->  _adding-bottom: %1em !important;\n
+  - FindBaseAddressString: "\x20padding-bottom: %1em"
+  - ReplaceString: {Offset: 1, Find: "p", Replace: "_"}
+
+Custom kepub default margins:
+  - Enabled: no
+  - Description: |
+      Sets the built-in minimum margin for KePub books and Pocket articles to
+      zero, the same as it is in ePub books. This only affects left/right margins
+      in normal reading mode, but all four margins in full-screen mode.
+  - BaseAddress: "ContentSettingManager::readerDefaultMargins(Device const&, bool)"
+  - ReplaceInt: {Offset: 52, Find: 60, Replace: 0} # Device = AuraOne, Type = Japanese kepub
+  - ReplaceInt: {Offset: 54, Find: 32, Replace: 0} # Device = AuraOne, Type = pocket article or non-Japanese kepub
+  - ReplaceInt: {Offset: 58, Find: 20, Replace: 0} # Device = Touch/Mini, Type = Any
+  - ReplaceInt: {Offset: 20, Find: 45, Replace: 0} # Device = Other, Type = Japanese kepub
+  - ReplaceInt: {Offset: 22, Find: 25, Replace: 0} # Device = Other, Type = pocket article or non-Japanese kepub
+
+Block WiFi firmware upgrade:
+  - Enabled: no
+  - PatchGroup: Firmware upgrade options
+  - Description: |
+      WARNING! THIS IS A DANGEROUS PATCH! READ THE INFORMATION BELOW CAREFULLY!
+
+      THIS PATCH IS UNTESTED, as there is no way to be sure it still works until
+      the next firmware version is released. If it works then the firmware will
+      not be upgraded during a WiFi sync, but you will still be able to upgrade
+      manually or by syncing with the Kobo desktop.
+
+      THIS PATCH COULD RESULT IN A BOOT LOOP when signing out of your Kobo account
+      (Settings > Accounts > Sign out) or when invoking a factory reset from the
+      device information menu (Settings > Device information > Factory reset).
+      REMOVE THIS PATCH BEFORE USING EITHER OF THOSE OPTIONS.
+      A factory reset invoked using the hardware methods (such as holding down the
+      light button while switching on) should not be affected.
+  - FindReplaceString:
+      Find:    "UpgradeCheck/%1/%2/%3/%4/%5"
+      Replace: "UpgradeCheck/%1/%2/k/99.9/5"
+
+Custom Sleep/Power-off timeouts:
+  - Enabled: no
+  - PatchGroup: Sleep/Power-off timeouts
+  - Description: |
+      Changes the Sleep/Power-off timeout menu options from 5,10,15,30,45,60
+      minutes to 10,20,30,60,120,240 minutes.
+    # Values displayed on both menus
+  - FindBaseAddressString: "5 mins\0"
+  - ReplaceString: {Offset:  0, Find: "5 mins\0", Replace: "10 mins"}
+  - ReplaceString: {Offset:  8, Find: "10 mins",  Replace: "20 mins"}
+  - ReplaceString: {Offset: 16, Find: "15 mins",  Replace: "30 mins"}
+  - ReplaceString: {Offset: 24, Find: "30 mins",  Replace: "1 hour"}
+  - ReplaceString: {Offset: 32, Find: "45 mins",  Replace: "2 hours"}
+  - ReplaceString: {Offset: 38, Find: "60 mins",  Replace: "4 hours"}
+    # Replace values MOVed then added to the list in N3SettingsPowerView::initChoices:
+  - BaseAddress: "N3SettingsPowerView::initChoices()"
+  - ReplaceInt: {Offset:  56, Find:  5, Replace:   10}
+  - ReplaceInt: {Offset: 118, Find: 10, Replace:   20}
+  - ReplaceInt: {Offset: 180, Find: 15, Replace:   30}
+  - ReplaceInt: {Offset: 240, Find: 30, Replace:   60}
+  - ReplaceInt: {Offset: 300, Find: 45, Replace:  120}
+  - ReplaceInt: {Offset: 360, Find: 60, Replace:  240}
+
+Set KePub hyphenation:
+  - Enabled: no
+  - Description: |
+      The built-in KePub stylesheet has a line * { -webkit-hyphens: auto; }
+      to turn on hyphenation, but it is only used if the device's justification
+      button is set to full justification. With this patch enabled hyphenation
+      will always be turned on, regardless of justification button setting.
+
+      (The publisher can still turn hyphenation off/on in the book's stylesheet.)
+    # == "justify"
+  - ReplaceBytes: {Base: "KepubBookReader::pageStyleCss(bool)", Offset: 2032, FindInstBLX: {SymPLT: "QString::operator==(QLatin1String) const"}, ReplaceH: 01 20 01 20} # Alternative 1: Always turn KePub hyphenation on
+# - ReplaceBytes: {Base: "KepubBookReader::pageStyleCss(bool)", Offset: 2032, FindInstBLX: {SymPLT: "QString::operator==(QLatin1String) const"}, ReplaceH: 00 20 00 20} # Alternative 2: Never turn KePub hyphenation on
+
+Force user line spacing in KePubs:
+  - Enabled: no
+  - Description: |
+      This patch will allow the line spacing set by the slider to take effect
+      in some problem KePub books with fixed linespacing (including ones where the
+      publisher has used <div> instead of <p> for paragraphs, or wrapped each
+      paragraph in a <span> and set the line-height on the span.) However it might
+      also override some line spacing that would better be left fixed, e.g. it can
+      cause problems with the spacing of paragraphs that begin with a raise-cap.
+    # body, p { line-height: %1 ... }  -->  body *  { line-height: %1 ... }
+  - FindBaseAddressString: "body, p { line-height: %1"
+  - ReplaceString: {Find: "body, p {", Replace: "body *  {", MustMatchLength: yes}
+    #
+    # Option: Comment out the replace_string line above and uncomment the one below
+    # for a less forceful version of this patch that has fewer side effects and
+    # should still work for most problem books, but not the ones where the publisher
+    # has set the line-height at <span> level.
+    #
+    # body, p { line-height: %1 ... }  -->  body,div,p{line-height:%1 ... }
+# - ReplaceString: {Find: "body, p { line-height: %", Replace: "body,div,p{line-height:%"}
+
+Force user line spacing in ePubs (part 1 of 2):
+  - Enabled: no
+  - Description: |
+      This is part 1 of 2. Also enable part 2 in librmsdk.so.1.0.0.patch
+      This patch prevents any line-height style set in the book's stylesheet from
+      being recognised. It will spoil the formatting of some books, but will
+      ensure that the line spacing set with the adjustment slider takes effect.
+  - FindBaseAddressString: "\0\0\x20line-height: %1"
+  - ReplaceString: {Offset: 3, Find: "l", Replace: "_"}
+
+Un-force font-family override p tags (std epubs):
+  - Enabled: no
+  - PatchGroup: ePub force font alternatives
+  - Description: |
+      This patch allows the font set for paragraphs by the publisher in the epub
+      stylesheet to override the font selected by the reader from the device.
+    #     body, p { font-family: -ua-default !important; }
+    # --> body    { font-family: -ua-default !important; }
+  - FindBaseAddressString: "body, p { font-family: -ua"
+  - ReplaceString: {Find: "body, p", Replace: "body  \x20", MustMatchLength: yes}
+
+Force user font-family in ePubs (Part 1 of 2):
+  - Enabled: no
+  - PatchGroup: ePub force font alternatives
+  - Description: |
+      This is part 1 of 2. Also enable part 2 in librmsdk.so.1.0.0.yaml.
+      This patch prevents any font-family style set in the book's stylesheet from
+      being recognised. It might spoil the style of books which use multiple fonts,
+      but will ensure that the font-family set from the device menu takes effect.
+  - FindBaseAddressString: "font-family: -ua-default; font-style: normal; font-weight: normal;"
+  - ReplaceString: {Find: "f", Replace: "_"}
+  - FindBaseAddressString: "font-family: -ua-default; font-style: italic; font-weight: normal;"
+  - ReplaceString: {Find: "f", Replace: "_"}
+  - FindBaseAddressString: "font-family: -ua-default; font-style: italic; font-weight: bold;"
+  - ReplaceString: {Find: "f", Replace: "_"}
+  - FindBaseAddressString: "font-family: -ua-default; font-style: normal; font-weight: bold;"
+  - ReplaceString: {Find: "f", Replace: "_"}
+  - FindBaseAddressString: "font-family: -ua-default !important;"
+  - ReplaceString: {Find: "f", Replace: "_"}
+
+ePub constant font sharpness:
+  - Enabled: no
+  - Description: |
+      With this patch the ePub reader will use a constant sharpness value of 0.2,
+      instead of the value set by the advanced font sharpness/weight slider. The
+      slider sharpness values range from -0.4(min.) to 0.2(max.), default -0.0666.
+    # -kobo-font-sharpness: %1; --> -kobo-font-sharpness:0.2;
+  - FindBaseAddressString: "\0\0 -kobo-font-sharpness: %1;"
+  - ReplaceString: {Offset: 3, Find: "-kobo-font-sharpness: %1", Replace: "-kobo-font-sharpness:0.2", MustMatchLength: yes}
+
+# MISSING: KePub constant font sharpness (not enough room for neutralizing the QString arg; we will probably need to patch that one out)
+
+Un-Force user text-align in div,p tags in KePubs:
+  - Enabled: no
+  - Description: |
+      This patch allows the text alignment set by the publisher in the kepub
+      stylesheet to override the alignment selected by the reader from the device.
+    #     div, p { text-align: %1 !important; }
+    # --> body   { text-align: %1 !important; }
+  - FindBaseAddressString: "div, p { text-align: %1"
+  - ReplaceString:
+      Find:    "div, p {"
+      Replace: "body   {"
+      MustMatchLength: yes
+
+Un-Force user font-family in KePubs:
+  - Enabled: no
+  - Description: |
+      The KePub reader uses a very heavy-handed method of setting the font selected
+      by the user, overriding all fonts set by the publisher in the book unless
+      "Publisher Default" is selected.
+      This patch lets the font-family set by the publisher in the KePub stylesheet
+      override the font-family selected by the reader from the device in some
+      cases, which allows a mix of user-selected and publisher-selected fonts.
+      Alternatives 1-3 give increasing preference to the publisher-selected fonts.
+  - FindBaseAddressString: "* { font-family: %1 !important; }\n"
+    #
+    # Alternative 1:
+    #     * { font-family: %1 !important; }\n
+    # --> div,p{font-family:%1!important; }\n
+  - ReplaceString:
+      Find: "* { font-family: %1 !important; }\n"
+      Replace: "div,p{font-family:%1!important; }\n"
+      MustMatchLength: yes
+    #
+    # Alternative 2: (Similar to ePub default)
+    #     * { font-family: %1 !important; }\n
+    # --> body,p{font-family:%1!important;}\n
+# - ReplaceString:
+#     Offset: 0
+#     Find: "* { font-family: %1 !important; }\n"
+#     Replace: "body,p{font-family:%1!important;}\n"
+#     MustMatchLength: yes
+    #
+    # Alternative 3: (similar to ePub with `Un-force font-family override p tags`)
+    #     * { font-family: %1 !important; }\n
+    # --> body{font-family:%1 !important; }\n
+# - ReplaceString:
+#     Offset: 0
+#     Find: "* { font-family: %1 !important; }\n"
+#     Replace: "body{font-family:%1 !important; }\n"
+#     MustMatchLength: yes
+
+Un-force link decoration in KePubs:
+  - Enabled: no
+  - Description: Disables the following link decoration CSS in the KePub stylesheet.
+    # a:link, a:visited, a:hover, a:active {
+    #   border-bottom: 1px dotted black !important;
+    #   color: #696969 !important;
+    # }
+  - FindBaseAddressString: "a:link, a:visited, a:hover, a:active {"
+  - ReplaceString: {Offset: 0x27, Find: "b", Replace: "_"} # Disable border-bottom style
+  - ReplaceString: {Offset: 0x53, Find: "c", Replace: "_"} # Disable color style
+
+# MISSING: Ignore .otf fonts (this will probably need to become a fontickle patch)

--- a/src/versions/4.40.23081/libnickel.so.1.0.0.yaml/jackie_w.yaml
+++ b/src/versions/4.40.23081/libnickel.so.1.0.0.yaml/jackie_w.yaml
@@ -1,0 +1,122 @@
+# The following patch(es) were made by jackie_w
+
+Dictionary text font-family/font-size/line-height:
+  - Enabled: no
+  - Description: |
+      This patch allows you to to customise the appearance of the text
+      in the pop-up and full-screen dictionary widgets.
+      4.17.13651: improved to also reduce the blank lines displayed in many
+                  sideloaded custom dictionaries which contain <blockquote>.
+      4.24.15676: enforced update to accommodate Kobo changes related to new
+                  dictionaries being released Oct 1st 2020
+      See https://www.mobileread.com/forums/showpost.php?p=3521137&postcount=48
+      for screenshots
+      4.32.19501: major font handling changes. Customising font-family now very limited
+      #
+      You can change one or more of the following properties:
+      - font-family (very limited choice from fw >= 4.32.19501)
+      - font-size
+      - line-height
+      #
+      These are the Kobo defaults
+                Glo - serif (Georgia)  23px  1.4em
+                H2O - serif (Georgia)  29px  1.4em
+              GloHD - serif (Georgia)  32px  1.4em
+            AuraONE - serif (Georgia)  42px  1.4em
+
+  # Stage 1: Change DictionaryView to remove some %variables
+  # from:
+  #   body { padding-left: %3px; }
+  #   body { font: %1px %4, serif; line-height: 1.4em; }
+  #   span.word { font-weight: bold; font-size: 130%; margin-left: -%3px; }
+  #   div.descriptionFont { font-family: serif; }
+  #   ol { font-size: %1px; margin-left: %2em; margin-top: 0px; }
+  #   ol p { font-size: %1px; }
+  #   i, i * { font-style: italic; }
+  #   b, b * { font-weight: bold; }
+  #   .sc, .sc * { font-variant: small-caps; }
+  #   .block, .border { border-radius: 3px; padding: 0em .2em; font-size: 90%; }
+  # to:
+  #   body {font-size:%1px; line-height:1.40em; font-family:%4, serif                           ;}
+  #   body {padding-left:0.5em}
+  #   span.word {font-weight:bold; font-size:130%; margin-left:-0.3em}
+  #   ol {margin-left:1em; margin-top:0}
+  #   blockquote {margin:.3em 0 .3em 1em}
+  #   blockquote>blockquote {margin:-.3em 0 0 2em}
+  #   i, i * {font-style:italic}
+  #   b, b * {font-weight:bold}
+  #   .sc, .sc * {font-variant:small-caps}
+  #   .block, .border {border-radius:3px; padding:0 .2em; font-size:90%}
+
+  # ##### N.B. Do not change the next 4 lines #####
+  - FindReplaceString:
+      Find:    "body { padding-left: %3px; }\nbody { font: %1px %4, serif; line-height: 1.4em; }\nspan.word { font-weight: bold; font-size: 130%; margin-left: -%3px; }\ndiv.descriptionFont { font-family: serif; }\nol { font-size: %1px; margin-left: %2em; margin-top: 0px; }\nol p { font-size: %1px; }\ni, i * { font-style: italic; }\nb, b * { font-weight: bold; }\n.sc, .sc * { font-variant: small-caps; }\n.block, .border { border-radius: 3px; padding: 0em .2em; font-size: 90%; }\n"
+      Replace: "body {font-size:%1px; line-height:1.40em; font-family:%4, serif                           ;}\nbody {padding-left:0.5em}\nspan.word {font-weight:bold; font-size:130%; margin-left:-0.3em}\nol {margin-left:1em; margin-top:0}\nblockquote {margin:.3em 0 .3em 1em}\nblockquote>blockquote {margin:-.3em 0 0 2em}\ni, i * {font-style:italic}\nb, b * {font-weight:bold}\n.sc, .sc * {font-variant:small-caps}\n.block, .border {border-radius:3px; padding:0 .2em; font-size:90%}\n"
+      MustMatchLength: yes
+  # ##### N.B. Do not change anything above this line #####
+
+  # Stage 2: N.B. You MUST keep old and new strings EXACTLY the same length
+
+  # N.B: From fw 4.32.19508 these are the only customised font-family values reported as having any effect
+  #      The first example will use the default sans-serif font, i.e. Avenir for most non-CJK GUI language locales
+  
+  # Un-comment ONE ONLY of the following 4 ReplaceString examples
+  #- ReplaceString: {Offset: 54, Find: "%4, serif ",             Replace: "sans-serif",             MustMatchLength: yes}
+  #- ReplaceString: {Offset: 54, Find: "%4, serif             ", Replace: "'KBJ-TsukuMin Pr6N RB'", MustMatchLength: yes}
+  #- ReplaceString: {Offset: 54, Find: "%4, serif            ",  Replace: "'KBJ-UDKakugo Pr6N M'",  MustMatchLength: yes}
+  #- ReplaceString: {Offset: 54, Find: "%4, serif       ",       Replace: "'AR UDJingxihei'",       MustMatchLength: yes}
+
+  # Un-comment and edit next line to change font-size
+  #- ReplaceString: {Offset: 16, Find: "%1px", Replace: "32px", MustMatchLength: yes}
+
+  # Un-comment and edit next line to change line spacing
+  #- ReplaceString: {Offset: 34, Find: "1.40em", Replace: "1.30em", MustMatchLength: yes}
+
+
+Custom navigation menu page number text:
+  - Enabled: no
+  - Description: Changes the page number text format in the reading navigation menu
+  - FindReplaceString: {Find: "Page %1 of %2", Replace: "%1 / %2"}
+
+# The next 2 patches are alternatives. Enable ONE ONLY.
+# They have replaced the old patch named 'KePub stylesheet additions'
+
+KePub stylesheet additions - text justify:
+  - Enabled: no
+  - PatchGroup: KePub stylesheet additions alternatives
+  - Description: Make full justification the default in KePubs
+  - FindBaseAddressString: ".KBSearchResult, .KBAnnotation, .KBHighlighting {"
+  # *** Don't change anything in the 4 ReplaceString lines below ***
+  - ReplaceString: {Find: ".KBSearchResult, .KBAnnotation, .KBHighlighting { font-size: 100% !important; -webkit-text-combine: inherit !important; }\n", Replace: ".KBSearchResult,.KBAnnotation,.KBHighlighting{font-size:100%!important;-webkit-text-combine:inherit!important}.KBAnnotatio", MustMatchLength: yes}
+  - ReplaceString: {Offset: 122, Find: ".KBAnnotation[writingMode=\"horizontal-tb\"] { border-bottom: 2px solid black !important; }\n", Replace: "n[writingMode=\"horizontal-tb\"]{border-bottom:2px solid #000!important}.KBAnnotation[writin", MustMatchLength: yes}
+  - ReplaceString: {Offset: 212, Find: ".KBAnnotation[writingMode=\"vertical-rl\"] { border-right: 2px solid black !important; }\n", Replace: "gMode=\"vertical-rl\"]{border-right:2px solid #000!important}.KBAnnotation[writingMode=\"v", MustMatchLength: yes}
+  - ReplaceString: {Offset: 299, Find: ".KBAnnotation[writingMode=\"vertical-lr\"] { border-left: 2px solid black !important; }", Replace: "ertical-lr\"]{border-left:2px solid #000!important}/*********************************/", MustMatchLength: yes}
+  # *** Don't change anything in the 4 ReplaceString lines above ***
+  #
+  - FindReplaceString: {Find: "/*********************************/", Replace: "body{text-align:justify           }", MustMatchLength: yes}
+
+KePub stylesheet additions - word-spacing:
+  - Enabled: no
+  - PatchGroup: KePub stylesheet additions alternatives
+  - Description: | 
+        Reduces the space between words in KePubs. 
+        Probably only useful to those who prefer to read KePubs with left/right full justification, i.e. not ragged-right edge.
+        See https://www.mobileread.com/forums/showpost.php?p=4217711&postcount=28
+            for screenshots showing the effect of enabling this patch.
+  - FindBaseAddressString: ".KBSearchResult, .KBAnnotation, .KBHighlighting {"
+  # *** Don't change anything in the 4 ReplaceString lines below ***
+  - ReplaceString: {Find: ".KBSearchResult, .KBAnnotation, .KBHighlighting { font-size: 100% !important; -webkit-text-combine: inherit !important; }\n", Replace: ".KBSearchResult,.KBAnnotation,.KBHighlighting{font-size:100%!important;-webkit-text-combine:inherit!important}.KBAnnotatio", MustMatchLength: yes}
+  - ReplaceString: {Offset: 122, Find: ".KBAnnotation[writingMode=\"horizontal-tb\"] { border-bottom: 2px solid black !important; }\n", Replace: "n[writingMode=\"horizontal-tb\"]{border-bottom:2px solid #000!important}.KBAnnotation[writin", MustMatchLength: yes}
+  - ReplaceString: {Offset: 212, Find: ".KBAnnotation[writingMode=\"vertical-rl\"] { border-right: 2px solid black !important; }\n", Replace: "gMode=\"vertical-rl\"]{border-right:2px solid #000!important}.KBAnnotation[writingMode=\"v", MustMatchLength: yes}
+  - ReplaceString: {Offset: 299, Find: ".KBAnnotation[writingMode=\"vertical-lr\"] { border-left: 2px solid black !important; }", Replace: "ertical-lr\"]{border-left:2px solid #000!important}/*********************************/", MustMatchLength: yes}
+  # *** Don't change anything in the 4 ReplaceString lines above ***
+  #
+  # Customise the -0.05 value if you prefer.
+  # N.B. Be careful, if it's too big some words may get joined together.
+  - FindReplaceString: {Find: "/*********************************/", Replace: "body{word-spacing:-0.05em         }", MustMatchLength: yes}
+
+# KePub stylesheet additions - optimizeSpeed: retired
+# KePub stylesheet additions - optimizeLegibility: retired
+# Edit Kobo config (.kobo/Kobo/Kobo eReader.conf) to achieve same result.
+# For more detail, see MR post https://www.mobileread.com/forums/showpost.php?p=4215805&postcount=40
+

--- a/src/versions/4.40.23081/libnickel.so.1.0.0.yaml/jcn363.yaml
+++ b/src/versions/4.40.23081/libnickel.so.1.0.0.yaml/jcn363.yaml
@@ -1,0 +1,23 @@
+# The following patch(es) are ported from jcn363's patches
+
+Shorten dictionary entry not found message:
+  - Enabled: no
+  - Description: |
+      Idea by pakoe
+      cf. https://www.mobileread.com/forums/showpost.php?p=3043631&postcount=111
+  - FindReplaceString:
+        Find:    "Your search for &ldquo;%1&rdquo; did not match any words in the dictionary. The closest match was &ldquo;%2&rdquo;."
+        Replace: "No match for &ldquo;%1&rdquo;, closest match was &ldquo;%2&rdquo;."
+
+Change Wikipedia search language:
+  - Enabled: no
+  - Description: |
+      The patch set the search language in Wikipedia.
+      Replace the "en" (in both the replace_string lines) to language code you want.
+      For example English is "en" (set as default), for German is "de", for Russian is "ru".
+  - FindReplaceString:
+      Find:    "\0https://%1.m.wikipedia.org/wiki/Special:Search\0"
+      Replace: "\0https://es.m.wikipedia.org/wiki/Special:Search\0"
+  - FindReplaceString:
+      Find:    "\0https://%1.wikipedia.org/wiki/Special:Search\0"
+      Replace: "\0https://es.wikipedia.org/wiki/Special:Search\0"

--- a/src/versions/4.40.23081/libnickel.so.1.0.0.yaml/keyboard.yaml
+++ b/src/versions/4.40.23081/libnickel.so.1.0.0.yaml/keyboard.yaml
@@ -1,0 +1,177 @@
+# The following keyboard patches were originally by GeoffR and updated by various users.
+
+Cyrillic Keyboard (GloHD/ClaraHD/AuraOne/H2O2):
+  # Updated by Bald Eagle for 4.18.13737 (https://www.mobileread.com/forums/showpost.php?p=3894655&postcount=84)
+  - Enabled: no
+  - PatchGroup: Keyboard alternatives
+  - Description: |
+      Replaces keys on the Extended Latin keypad with Cyrillic alternatives.
+
+      Note that after the device boots, the keypad might just show blank squares
+      until after the first book has been opened.
+      Also note that long-pressing keys on the base keypad will no longer show
+      the appropriate list of Extended Latin keys.
+  # Replace layout sign
+  - FindBaseAddressString: "ÉÀÇ"
+  - ReplaceString: {Offset: 0, Find: "ÉÀÇ", Replace: "АБВ"}
+  # Change keyboard layout
+  - FindBaseAddressString: "ý\0\0ÿ\0\0š\0\0ž\0\0"
+  # Top row, left to right (10 keys):
+  - ReplaceString: {Offset: 0x00, Find: "ý\0", Replace: "ё"}
+  - ReplaceString: {Offset: 0x04, Find: "ÿ\0", Replace: "э"}
+  - ReplaceString: {Offset: 0x08, Find: "š\0", Replace: "ä"}
+  - ReplaceString: {Offset: 0x0C, Find: "ž\0", Replace: "ö"}
+  - ReplaceString: {Offset: 0x10, Find: "æ\0", Replace: "ü"}
+  - ReplaceString: {Offset: 0x14, Find: "œ\0", Replace: "µ"}
+  - ReplaceString: {Offset: 0x18, Find: "þ\0", Replace: "ю"}
+  #- ReplaceString: {Offset: -56, Find: "ß\0", Replace: ","}
+  - ReplaceString: {Offset: 0x1C, Find: "ĳ\0", Replace: "х"}
+  - ReplaceString: {Offset: 0x20, Find: "ŀ\0", Replace: "ъ"}
+  # Second row, left to right (10 keys):
+  - ReplaceString: {Offset: 0x28, Find: "à\0", Replace: "й"}
+  - ReplaceString: {Offset: 0x2C, Find: "á\0", Replace: "ц"}
+  - ReplaceString: {Offset: 0x30, Find: "â\0", Replace: "у"}
+  - ReplaceString: {Offset: 0x34, Find: "ä\0", Replace: "к"}
+  - ReplaceString: {Offset: 0x38, Find: "ã\0", Replace: "е"}
+  - ReplaceString: {Offset: 0x3C, Find: "å\0", Replace: "н"}
+  - ReplaceString: {Offset: 0x40, Find: "è\0", Replace: "г"}
+  - ReplaceString: {Offset: 0x44, Find: "é\0", Replace: "ш"}
+  - ReplaceString: {Offset: 0x48, Find: "ê\0", Replace: "щ"}
+  - ReplaceString: {Offset: 0x4C, Find: "ë\0", Replace: "з"}
+  # Third row, left to right (10 keys):
+  - ReplaceString: {Offset: 0x50, Find: "ò\0", Replace: "ф"}
+  - ReplaceString: {Offset: 0x54, Find: "ó\0", Replace: "ы"}
+  - ReplaceString: {Offset: 0x58, Find: "ô\0", Replace: "в"}
+  - ReplaceString: {Offset: 0x5C, Find: "ö\0", Replace: "а"}
+  - ReplaceString: {Offset: 0x60, Find: "õ\0", Replace: "п"}
+  - ReplaceString: {Offset: 0x64, Find: "ø\0", Replace: "р"}
+  - ReplaceString: {Offset: 0x68, Find: "ì\0", Replace: "о"}
+  - ReplaceString: {Offset: 0x6C, Find: "í\0", Replace: "л"}
+  - ReplaceString: {Offset: 0x70, Find: "î\0", Replace: "д"}
+  - ReplaceString: {Offset: 0x74, Find: "ï\0", Replace: "ж"}
+  # Fourth row, left to right (8 keys):
+  - ReplaceString: {Offset: 0x78, Find: "ù\0", Replace: "я"}
+  - ReplaceString: {Offset: 0x7C, Find: "ú\0", Replace: "ч"}
+  - ReplaceString: {Offset: 0x80, Find: "û\0", Replace: "с"}
+  - ReplaceString: {Offset: 0x84, Find: "ü\0", Replace: "м"}
+  - ReplaceString: {Offset: 0x88, Find: "ñ\0", Replace: "и"}
+  - ReplaceString: {Offset: 0x8C, Find: "ç\0", Replace: "т"}
+  - ReplaceString: {Offset: 0x90, Find: "đ\0", Replace: "ь"}
+  - ReplaceString: {Offset: 0x94, Find: "ł\0", Replace: "б"}
+
+Greek Keyboard (GloHD/ClaraHD/AuraOne/H2O2):
+  # Updated by Bald Eagle for 4.18.13737 (https://www.mobileread.com/forums/showpost.php?p=3895481&postcount=125)
+  - Enabled: no
+  - PatchGroup: Keyboard alternatives
+  - Description: |
+      Replaces keys on the Extended Latin keypad with Greek alternatives.
+
+      Note that after the device boots, the keypad might just show blank squares
+      until after the first book has been opened.
+      Also note that long-pressing keys on the base keypad will no longer show
+      the appropriate list of Extended Latin keys.
+  # Replace layout sign Greek
+  - FindBaseAddressString: "ÉÀÇ"
+  - ReplaceString: {Offset: 0, Find: "ÉÀÇ", Replace: "ελ"}
+  # Change keyboard layout
+  - FindBaseAddressString: "ý\0\0ÿ\0\0š\0\0ž\0\0"
+  # Top row, left to right (10 keys):
+  - ReplaceString: {Offset: 0x00, Find: "ý\0", Replace: "ό"}
+  - ReplaceString: {Offset: 0x04, Find: "ÿ\0", Replace: "ύ"}
+  - ReplaceString: {Offset: 0x08, Find: "š\0", Replace: "ϋ"}
+  - ReplaceString: {Offset: 0x0C, Find: "ž\0", Replace: ":"}
+  - ReplaceString: {Offset: 0x10, Find: "æ\0", Replace: "ά"}
+  - ReplaceString: {Offset: 0x14, Find: "œ\0", Replace: "έ"}
+  - ReplaceString: {Offset: 0x18, Find: "þ\0", Replace: "ί"}
+  - ReplaceString: {Offset: 0x1C, Find: "ĳ\0", Replace: "-"}
+  - ReplaceString: {Offset: 0x20, Find: "ŀ\0", Replace: "_"}
+  # Second row, left to right (10 keys):
+  - ReplaceString: {Offset: 0x28, Find: "à\0", Replace: ";"}
+  - ReplaceString: {Offset: 0x2C, Find: "á\0", Replace: "ς"}
+  - ReplaceString: {Offset: 0x30, Find: "â\0", Replace: "ε"}
+  - ReplaceString: {Offset: 0x34, Find: "ä\0", Replace: "ρ"}
+  - ReplaceString: {Offset: 0x38, Find: "ã\0", Replace: "τ"}
+  - ReplaceString: {Offset: 0x3C, Find: "å\0", Replace: "υ"}
+  - ReplaceString: {Offset: 0x40, Find: "è\0", Replace: "θ"}
+  - ReplaceString: {Offset: 0x44, Find: "é\0", Replace: "ι"}
+  - ReplaceString: {Offset: 0x48, Find: "ê\0", Replace: "ο"}
+  - ReplaceString: {Offset: 0x4C, Find: "ë\0", Replace: "π"}
+  # Third row, left to right (10 keys):
+  - ReplaceString: {Offset: 0x50, Find: "ò\0", Replace: "α"}
+  - ReplaceString: {Offset: 0x54, Find: "ó\0", Replace: "σ"}
+  - ReplaceString: {Offset: 0x58, Find: "ô\0", Replace: "δ"}
+  - ReplaceString: {Offset: 0x5C, Find: "ö\0", Replace: "φ"}
+  - ReplaceString: {Offset: 0x60, Find: "õ\0", Replace: "γ"}
+  - ReplaceString: {Offset: 0x64, Find: "ø\0", Replace: "η"}
+  - ReplaceString: {Offset: 0x68, Find: "ì\0", Replace: "ξ"}
+  - ReplaceString: {Offset: 0x6C, Find: "í\0", Replace: "κ"}
+  - ReplaceString: {Offset: 0x70, Find: "î\0", Replace: "λ"}
+  - ReplaceString: {Offset: 0x74, Find: "ï\0", Replace: ","}
+  # Fourth row, left to right (8 keys):
+  - ReplaceString: {Offset: 0x78, Find: "ù\0", Replace: "ζ"}
+  - ReplaceString: {Offset: 0x7C, Find: "ú\0", Replace: "χ"}
+  - ReplaceString: {Offset: 0x80, Find: "û\0", Replace: "ψ"}
+  - ReplaceString: {Offset: 0x84, Find: "ü\0", Replace: "ω"}
+  - ReplaceString: {Offset: 0x88, Find: "ñ\0", Replace: "β"}
+  - ReplaceString: {Offset: 0x8C, Find: "ç\0", Replace: "ν"}
+  - ReplaceString: {Offset: 0x90, Find: "đ\0", Replace: "μ"}
+  - ReplaceString: {Offset: 0x94, Find: "ł\0", Replace: "."}
+
+Bulgarian Phonetic Keyboard (GloHD/ClaraHD/AuraOne/H2O2/Forma/Libra):
+  # Created by Svens (https://www.mobileread.com/forums/showpost.php?p=3977092&postcount=51)
+  - Enabled: no
+  - PatchGroup: Keyboard alternatives
+  - Description: |
+      Replaces keys on the Extended Latin keypad with Bulgarian alternatives.
+
+      Note that after the device boots, the keypad might just show blank squares
+      until after the first book has been opened.
+      Also note that long-pressing keys on the base keypad will no longer show
+      the appropriate list of Extended Latin keys.
+  # Replace layout sign
+  - FindBaseAddressString: "ÉÀÇ"
+  - ReplaceString: {Offset: 0, Find: "ÉÀÇ", Replace: "АБВ"}
+  # Change keyboard layout
+  - FindBaseAddressString: "ý\0\0ÿ\0\0š\0\0ž\0\0"
+  # Top row, left to right (10 keys):
+  - ReplaceString: {Offset: 0x00, Find: "ý\0", Replace: "ч"}
+  - ReplaceString: {Offset: 0x04, Find: "ÿ\0", Replace: "э"}
+  - ReplaceString: {Offset: 0x08, Find: "š\0", Replace: "ё"}
+  - ReplaceString: {Offset: 0x0C, Find: "ž\0", Replace: "ы"}
+  - ReplaceString: {Offset: 0x10, Find: "æ\0", Replace: ","}
+  - ReplaceString: {Offset: 0x14, Find: "œ\0", Replace: ";"}
+  - ReplaceString: {Offset: 0x18, Find: "þ\0", Replace: "!"}
+  - ReplaceString: {Offset: -56, Find: "ß\0", Replace: "?"}
+  - ReplaceString: {Offset: 0x1C, Find: "ĳ\0", Replace: "ш"}
+  - ReplaceString: {Offset: 0x20, Find: "ŀ\0", Replace: "щ"}
+    # Second row, left to right (10 keys):
+  - ReplaceString: {Offset: 0x28, Find: "à\0", Replace: "я"}
+  - ReplaceString: {Offset: 0x2C, Find: "á\0", Replace: "в"}
+  - ReplaceString: {Offset: 0x30, Find: "â\0", Replace: "е"}
+  - ReplaceString: {Offset: 0x34, Find: "ä\0", Replace: "р"}
+  - ReplaceString: {Offset: 0x38, Find: "ã\0", Replace: "т"}
+  - ReplaceString: {Offset: 0x3C, Find: "å\0", Replace: "ъ"}
+  - ReplaceString: {Offset: 0x40, Find: "è\0", Replace: "у"}
+  - ReplaceString: {Offset: 0x44, Find: "é\0", Replace: "и"}
+  - ReplaceString: {Offset: 0x48, Find: "ê\0", Replace: "о"}
+  - ReplaceString: {Offset: 0x4C, Find: "ë\0", Replace: "п"}
+    # Third row, left to right (10 keys):
+  - ReplaceString: {Offset: 0x50, Find: "ò\0", Replace: "а"}
+  - ReplaceString: {Offset: 0x54, Find: "ó\0", Replace: "с"}
+  - ReplaceString: {Offset: 0x58, Find: "ô\0", Replace: "д"}
+  - ReplaceString: {Offset: 0x5C, Find: "ö\0", Replace: "ф"}
+  - ReplaceString: {Offset: 0x60, Find: "õ\0", Replace: "г"}
+  - ReplaceString: {Offset: 0x64, Find: "ø\0", Replace: "х"}
+  - ReplaceString: {Offset: 0x68, Find: "ì\0", Replace: "й"}
+  - ReplaceString: {Offset: 0x6C, Find: "í\0", Replace: "к"}
+  - ReplaceString: {Offset: 0x70, Find: "î\0", Replace: "л"}
+  - ReplaceString: {Offset: 0x74, Find: "ï\0", Replace: "ю"}
+    # Fourth row, left to right (8 keys):
+  - ReplaceString: {Offset: 0x78, Find: "ù\0", Replace: "з"}
+  - ReplaceString: {Offset: 0x7C, Find: "ú\0", Replace: "ь"}
+  - ReplaceString: {Offset: 0x80, Find: "û\0", Replace: "ц"}
+  - ReplaceString: {Offset: 0x84, Find: "ü\0", Replace: "ж"}
+  - ReplaceString: {Offset: 0x88, Find: "ñ\0", Replace: "б"}
+  - ReplaceString: {Offset: 0x8C, Find: "ç\0", Replace: "н"}
+  - ReplaceString: {Offset: 0x90, Find: "đ\0", Replace: "м"}
+  - ReplaceString: {Offset: 0x94, Find: "ł\0", Replace: "."}

--- a/src/versions/4.40.23081/libnickel.so.1.0.0.yaml/niluje.yaml
+++ b/src/versions/4.40.23081/libnickel.so.1.0.0.yaml/niluje.yaml
@@ -1,0 +1,10 @@
+# The following patch(es) are maintained by NiLuJe
+
+# This is a simple conversion of @frostschutz MiniClock patch
+# c.f., https://github.com/frostschutz/Kobo/blob/13a274f582e1e70cc8f865347f1bf113209f8320/MiniClock/usr/local/MiniClock/miniclock.sh#L179-L197
+# It simply prevents Nickel from grabbing exclusive access to the synthetic NTX input device,
+# which MiniClock may want to have acccess to in order to catch page turn buttons on devices who happen to feature such buttons ;).
+Don't grab exclusive access to event0:
+  - Enabled: no
+  - Description: Allows third-party tools to read the event0 input device
+  - FindReplaceString: {Find: "%0::keymap=keys/device.qmap::grab=1", Replace: "%0::keymap=keys/device.qmap::grab=0"}

--- a/src/versions/4.40.23081/libnickel.so.1.0.0.yaml/pgaskin.yaml
+++ b/src/versions/4.40.23081/libnickel.so.1.0.0.yaml/pgaskin.yaml
@@ -524,7 +524,7 @@ Customize ComfortLight settings:
   # In an unnamed subroutine two layers into FrontLightPopupController::loadView
   # (find it by going back from QTime::addSecs), the times for the dropdown are
   # generated into a QVector<QPair<QString, QTime>> with a simple loop.
-  - BaseAddress: 0xea841c # find the base of the unnamed subroutine with the x-ref to _ZN5QTimeC1Eiiii
+  - BaseAddress: 0xE9841c # find the base of the unnamed subroutine with the x-ref to _ZN5QTimeC1Eiiii
   #
   # Change the initial hour / first bedtime dropdown item passed to the QTime
   # constructor (mov r1, #21):

--- a/src/versions/4.40.23081/libnickel.so.1.0.0.yaml/pgaskin.yaml
+++ b/src/versions/4.40.23081/libnickel.so.1.0.0.yaml/pgaskin.yaml
@@ -391,7 +391,23 @@ Larger Sleep/Power-off timeouts:
   - ReplaceInt: {Offset: 300, Find: 45, Replace:  83}
   - ReplaceInt: {Offset: 360, Find: 60, Replace: 165}
 
-# TODO(geek1011): Allow rotation on all devices
+Allow rotation on all devices:
+  - Enabled: no
+  - Description: |
+      Enables rotation on all devices. This shows a rotation icon in the status
+      bar, which shows a menu allowing you to choose between portrait and landscape
+      when pressed. This icon is only shown on rotatable views (like the reader).
+      Unlike only the DeveloperSettings ForceAllowLandscape option, this patch
+      also makes the rotation icon show on the new reader as well.
+  # Always return true for ForceAllowLandscape:
+  - ReplaceBytes: {Base: "DevSettings::forceAllowLandscape()", Offset: 54, FindInstBLX: {SymPLT: "QVariant::toBool() const"}, ReplaceH: 4F F0 01 00}
+  # In ReadingMenuView::ReadingMenuView, replace the value of Device::hasOrientationSensor,
+  # which is passed to a function to hide/show the rotate icon:
+  - ReplaceBytes: {Base: "ReadingMenuView::updateReadingMenu()", Offset: 238, FindInstBLX: {SymPLT: "Device::hasOrientationSensor() const"}, ReplaceH: 4F F0 01 00}
+  # Also fix sizing of popup by doing the same in RotatePopup::RotatePopup, but
+  # note that this will make the Automatic option show too (and do nothing):
+  - ReplaceBytes: {Base: "RotatePopup::RotatePopup(QWidget*)", Offset: 190, FindInstBLX: {SymPLT: "Device::hasOrientationSensor() const"}, ReplaceH: 4F F0 01 00}
+
 
 Don't uppercase header/footer text:
   - Enabled: no
@@ -508,7 +524,7 @@ Customize ComfortLight settings:
   # In an unnamed subroutine two layers into FrontLightPopupController::loadView
   # (find it by going back from QTime::addSecs), the times for the dropdown are
   # generated into a QVector<QPair<QString, QTime>> with a simple loop.
-  - BaseAddress: 0xE8629C # find the base of the unnamed subroutine with the x-ref to _ZN5QTimeC1Eiiii
+  - BaseAddress: 0xea841c # find the base of the unnamed subroutine with the x-ref to _ZN5QTimeC1Eiiii
   #
   # Change the initial hour / first bedtime dropdown item passed to the QTime
   # constructor (mov r1, #21):

--- a/src/versions/4.40.23081/libnickel.so.1.0.0.yaml/pgaskin.yaml
+++ b/src/versions/4.40.23081/libnickel.so.1.0.0.yaml/pgaskin.yaml
@@ -1,0 +1,592 @@
+# The following patch(es) are by pgaskin (geek1011)
+
+Both page turn buttons go next:
+  - Enabled: no
+  - Description: Make both page turn buttons on the Forma go next in the reader.
+  - ReplaceBytes:
+      Base:          "ReadingView::keyPressEvent(QKeyEvent*)"
+      Offset:        82
+      FindInstBW:    {SymPLTTail: "ReadingView::prevPageWithTimer()"}
+      ReplaceInstBW: {SymPLTTail: "ReadingView::nextPageWithTimer()"}
+
+Both page turn sides go next:
+  - Enabled: no
+  - Description: Make both page turn sides go next in the reader.
+  # In ReadingView::processTap(TapGesture*) where the page direction is checked:
+  - BaseAddress:  {Sym: "ReadingView::processTap(TapGesture*)", Rel: 564}
+  - ReplaceBytes: {Offset:  0, FindInstBLX: {SymPLT: "ReadingView::leftToRightPageProgressDirection() const"}, CheckOnly: true}
+  # nop the branch for checking if left-to-right (so it always runs the swap of back/forward)
+  - ReplaceBytes: {Offset:  4, FindH: 18 B9, ReplaceInstNOP: true}
+  # where r3 = *(r7+0x18) (back) and r2 = *(r7+0x20) (forward), then they are stored in reverse,
+  # instead of storing each one, just store forward (by changing the source register in the str
+  # instruction)
+  - ReplaceBytes: {Offset: 10, FindH: 3B 62, ReplaceH: 3A 62}
+  # This patch could have also been done later on where the tap point is checked against different
+  # QRects, but that's a lot more complicated due to the use of QHash s of pointers to functions.
+
+Increase page navigation history:
+  - Enabled: no
+  - Description: Increases the number of dots marking navigation history on the scrubber.
+  # Replace the immediate value for the cmp r1, #2 before the bgt to the inlined
+  # QVector::removeFirst() (i.e. QVector::erase(start, start+1)):
+  - BaseAddress: "BookmarkHistoryMixin::pushBookmark(Bookmark const&)"
+  - ReplaceInt: {Offset: 24, Find: 2, Replace: 4} # note: you can set the replacement to whatever you want, but it MUST be > 1 or bad things will happen
+
+Replace adobe page numbers toggle with invert screen:
+  - Enabled: no
+  - Description: |
+      Replaces the adobe page numbers toggle in reading settings with an invert
+      screen one. Due to recent firmware changes (since 18220, it is set by the
+      kobo QPA during initialization), it will only take effect after a reboot.
+      See https://github.com/pgaskin/NickelMenu/issues/111 for more information.
+  # Settings page
+  - BaseAddress:  "N3SettingsReadingView::N3SettingsReadingView(QWidget*)"
+  - ReplaceBytes: {Offset: 884, FindInstBLX: {SymPLT: "ReadingSettings::getShowAdobePageNumbers()"},     ReplaceInstBLX: {SymPLT: "FeatureSettings::invertScreen()"}}
+  # Settings page controller
+  - BaseAddress:  {Sym: "N3SettingsReadingController::showAdobePageNumbersToggled()"}
+  - ReplaceBytes: {Offset:  74, FindInstBLX: {SymPLT: "ReadingSettings::getShowAdobePageNumbers()"},     ReplaceInstBLX: {SymPLT: "FeatureSettings::invertScreen()"}}
+  - ReplaceBytes: {Offset:  86, FindInstBLX: {SymPLT: "ReadingSettings::setShowAdobePageNumbers(bool)"}, ReplaceInstBLX: {SymPLT: "FeatureSettings::setInvertScreen(bool)"}}
+  # Settings page text
+  - FindReplaceString: {Find: "Show Adobe EPUB page numbers", Replace: "Invert screen"}
+
+Always show confirmation dialog before upgrading:
+  - Enabled: no
+  - PatchGroup: Firmware upgrade options
+  - Description: This patch makes the confirmation dialog always show before upgrading.
+  - BaseAddress:  "UpgradeManager::requestUpgradeConfirmation(UpgradeType, QString const&)"
+  - ReplaceBytes: {Offset: 22, FindH:       01 2C,                                  ReplaceH: A4 42}       # make the optional UpgradeType check always true (CMP r4, #1 -> CMP r4, r4)
+  - ReplaceBytes: {Offset: 42, FindInstBLX: {SymPLT: "UpgradeManager::isSilent()"}, ReplaceH: 4F F0 00 00} # make the call to UpgradeManager::isSilent always false (MOV r0, #0)
+
+Allow USB storage even when device locked:
+  - Enabled: no
+  - Description: |
+      Always allows USB storage even when the device is locked. When combined
+      with an enabled lock screen, this patch allows recovery from almost any
+      segfaulting patch without a factory reset, as most code isn't executed
+      until after the initial unlock. WARNING - this patches renders the lock
+      screen security completely useless! But, for some security by obscurity
+      this will only take effect when you plug it in while the sleep screen is
+      visible.
+  # Never reject the permission request (i.e. don't set *r5 = false), even when
+  # the PIN entry dialog is enabled:
+  - ReplaceBytes:
+      Base: "N3PowerWorkflowManager::onUSBPlugPermissionRequest(PermissionRequest*)"
+      Offset: 40
+      FindH: 2B 70    # strb r3, [r5]
+      ReplaceInstNOP: true
+
+Hide browser from beta features:
+  - Enabled: no
+  - Description: Hides the built-in browser from beta features.
+  - ReplaceBytes:
+      Base:        "N3SettingsExtrasView::N3SettingsExtrasView(QWidget*)"
+      Offset:      1530
+      FindInstBLX: {SymPLT: "Device::isParentalControlEnabled() const"}
+      ReplaceH:    4F F0 01 00
+  - ReplaceBytes:
+      Base:        {Sym: "SelectionMenuController::setupMainOptions()"}
+      Offset:      194
+      FindInstBLX: {SymPLT: "Device::isParentalControlEnabled() const"}
+      ReplaceH:    4F F0 01 00
+
+Remove beta features not supported text:
+  - Enabled: no
+  - Description: Does what it says to clear up the clutter.
+  - ReplaceBytes:
+      Base:           "Ui_N3SettingsExtrasView::retranslateUi(QWidget*)"
+      Offset:         96
+      FindInstBLX:    {SymPLT: "QLabel::setText(QString const&)"}
+      ReplaceInstBLX: {SymPLT: "QWidget::hide()"}
+
+Disable all tutorial dialogs:
+  - Enabled: no
+  - Description: |
+      Removes the annoying tutorials (and recurring dialogs). Note - I may
+      have missed a few of them. If I have, just open an issue on GitHub or
+      PM me (geek1011) on MobileRead, and I'll fix it.
+  # QVariant::toBool is called after getting the setting (of if it has/should
+  # show) as a QVariant. I am replacing this method as opposed to replacing the
+  # return value of the function because 1. A MOV instruction with an immediate
+  # (fixed) value is 4 long (rather than 2) and 2. This is simpler to update as
+  # I only need to update the function offset and the offset for each setting.
+  - ReplaceBytes: {Base: "DialogSettings::firstPurchaseCreditJitShown()",         Offset: 54, FindInstBLX: {SymPLT: "QVariant::toBool() const"}, ReplaceH: 4F F0 01 00}
+  - ReplaceBytes: {Base: "DialogSettings::quickTurnDialogShown()",                Offset: 54, FindInstBLX: {SymPLT: "QVariant::toBool() const"}, ReplaceH: 4F F0 01 00}
+  - ReplaceBytes: {Base: "DialogSettings::returningReaderDialogShown()",          Offset: 54, FindInstBLX: {SymPLT: "QVariant::toBool() const"}, ReplaceH: 4F F0 01 00}
+  - ReplaceBytes: {Base: "ApplicationSettings::koboLoveDialogShown()",            Offset: 54, FindInstBLX: {SymPLT: "QVariant::toBool() const"}, ReplaceH: 4F F0 01 00}
+  - ReplaceBytes: {Base: "ApplicationSettings::quickTourWidgetShown()",           Offset: 54, FindInstBLX: {SymPLT: "QVariant::toBool() const"}, ReplaceH: 4F F0 01 00}
+  - ReplaceBytes: {Base: "ApplicationSettings::overDriveFilterShown()",           Offset: 54, FindInstBLX: {SymPLT: "QVariant::toBool() const"}, ReplaceH: 4F F0 01 00}
+  - ReplaceBytes: {Base: "ApplicationSettings::wifiReminderDialogShown()",        Offset: 54, FindInstBLX: {SymPLT: "QVariant::toBool() const"}, ReplaceH: 4F F0 01 00}
+  - ReplaceBytes: {Base: "ApplicationSettings::readABookShown()",                 Offset: 54, FindInstBLX: {SymPLT: "QVariant::toBool() const"}, ReplaceH: 4F F0 01 00}
+  - ReplaceBytes: {Base: "ApplicationSettings::borrowDialogShown()",              Offset: 54, FindInstBLX: {SymPLT: "QVariant::toBool() const"}, ReplaceH: 4F F0 01 00}
+  - ReplaceBytes: {Base: "ApplicationSettings::quickTourShown()",                 Offset: 54, FindInstBLX: {SymPLT: "QVariant::toBool() const"}, ReplaceH: 4F F0 01 00}
+  - ReplaceBytes: {Base: "ApplicationSettings::libraryFTEShown()",                Offset: 54, FindInstBLX: {SymPLT: "QVariant::toBool() const"}, ReplaceH: 4F F0 01 00}
+  - ReplaceBytes: {Base: "ApplicationSettings::zoomFTEShown()",                   Offset: 54, FindInstBLX: {SymPLT: "QVariant::toBool() const"}, ReplaceH: 4F F0 01 00}
+  - ReplaceBytes: {Base: "ApplicationSettings::welcomeShown()",                   Offset: 54, FindInstBLX: {SymPLT: "QVariant::toBool() const"}, ReplaceH: 4F F0 01 00}
+  - ReplaceBytes: {Base: "ApplicationSettings::syncWarningDialogShown()",         Offset: 54, FindInstBLX: {SymPLT: "QVariant::toBool() const"}, ReplaceH: 4F F0 01 00}
+  - ReplaceBytes: {Base: "ApplicationSettings::addedToMyWordsDialogShown()",      Offset: 54, FindInstBLX: {SymPLT: "QVariant::toBool() const"}, ReplaceH: 4F F0 01 00}
+  - ReplaceBytes: {Base: "ApplicationSettings::longPressDialogShown()",           Offset: 54, FindInstBLX: {SymPLT: "QVariant::toBool() const"}, ReplaceH: 4F F0 01 00}
+  - ReplaceBytes: {Base: "ApplicationSettings::swipeDialogShown()",               Offset: 54, FindInstBLX: {SymPLT: "QVariant::toBool() const"}, ReplaceH: 4F F0 01 00}
+  - ReplaceBytes: {Base: "ApplicationSettings::syncReminderDialogShown()",        Offset: 54, FindInstBLX: {SymPLT: "QVariant::toBool() const"}, ReplaceH: 4F F0 01 00}
+  - ReplaceBytes: {Base: "ApplicationSettings::eReaderBooksManagementFTEShown()", Offset: 54, FindInstBLX: {SymPLT: "QVariant::toBool() const"}, ReplaceH: 4F F0 01 00}
+  - ReplaceBytes: {Base: "ApplicationSettings::libraryCuratedListsDialogShown()", Offset: 54, FindInstBLX: {SymPLT: "QVariant::toBool() const"}, ReplaceH: 4F F0 01 00}
+
+Remove recommendations (row1col2) from home screen:
+  - Enabled: no
+  - Description: |
+      By default, when there are less than 2 books open, a recommendations
+      column shows in the top right of the home screen. This patch hides it.
+  - ReplaceBytes:
+      Base:           "HomePageView::configureTopRight(HomePageWidgets)"
+      Offset:         48
+      FindH:          58 B1 # never skip hiding the top-right widget
+      ReplaceInstNOP: true
+
+Rename new home screen footer:
+  - Enabled: no
+  # This patch happens use shared strings in most versions, and may cause unusual
+  # replacements in other parts of the GUI (see https://github.com/pgaskin/kobopatch-patches/issues/34).
+  # This isn't usually an issue (and changes between versions), but occasionally,
+  # the keyboard uses a letter from one of these strings, and will type the letter
+  # from the replacement.
+  - FindReplaceString: {Find: "Find your next great read", Replace: "Find your next great read"}
+  - FindReplaceString: {Find: "Find your next book in Kobo Plus or our store", Replace: "Find your next book in Kobo Plus or our store"}
+  - ReplaceBytes:
+      Base:          "HomePageView::setOverDriveUser(OverDriveUser const&)"
+      Offset:         60
+      FindInstBLX:    {SymPLT: "GenericHomeWidget::setTitleText(QString)"}
+      ReplaceInstNOP: true
+    # You can enable the following replacement, but note that it might cause the o letter on the keyboard to change
+#  - FindReplaceString: {Find: "Shop Kobo", Replace: "9char-str"}
+
+Remove line from bottom tab bar:
+  - Enabled: no
+  - Description: Removes the line from the top of the bottom tab bar added in 4.23.15505.
+  # Instead of setting the minimum size of the QFrame for the line, hide it.
+  - ReplaceBytes:
+      Base:           "Ui_MainNavView::setupUi(QWidget*)"
+      Offset:         866
+      FindInstBLX:    {SymPLT: "QWidget::setMinimumSize(int, int)"}
+      ReplaceInstBLX: {SymPLT: "QWidget::hide()"}
+
+## Change Browse Kobo home screen link target ###
+# This patch allows you to change the target of the Browse Kobo link. To
+# rename the top description, use the rename home screen footer patch.
+#
+# The easy options for this patch are fairly limited, as BrowseKoboWidget::tapped
+# just calls the superclass event, then the call to DiscoverNavMixin::storeFront
+# in the PLT is tail-call optimized. This places a number of restrictions on the
+# replacement target, namely: the branch must be a branch and exchange, but not
+# link (lr must be unchanged to return correctly), which is implemented as a
+# 32-bit branch to a bx pc (nop branch, but still switch instruction sets)
+# immediately before a PLT entry to a nav mixin without any arguments (i.e.
+# must be static). Note that the first branch is relative to pc. Also, note that
+# in general, this requirement means anything called by StatusBarController (the
+# menu) can be used as a replacement.
+#
+# Basically, the following two steps are needed:
+# - In BrowseKoboWidget::tapped, change the tail-call to the bx before
+#   [something]NavMixin::[something] in the PLT.
+# - In the BrowseKoboWidget constructor, change which function is called to get
+#   the bottom text (Shop Kobo) from N3DeviceCharm::shopName (Shop Kobo / Walmart)
+#   to N3DeviceCharm::[something] (note that there isn't enough room to
+#   load an entirely different string here).
+
+Change Browse Kobo home screen link target - Activity:
+  - Enabled: no
+  - PatchGroup: Browse Kobo link target
+  - Description: See the comment above.
+  - ReplaceBytes:
+      Base:          "BrowseKoboWidget::tapped()"
+      Offset:        26
+      FindInstBW:    {SymPLTTail: "DiscoverNavMixin::storefront()"}        # Store
+      ReplaceInstBW: {SymPLTTail: "ReadingLifeNavMixin::chooseActivity()"} # Activity
+  - ReplaceBytes:
+      Base:          "BrowseKoboWidget::tapped()"
+      Offset:        36
+      FindInstBW:    {SymPLTTail: "StoreNavMixin::overDriveFeaturedLists()"} # OverDrive
+      ReplaceInstBW: {SymPLTTail: "ReadingLifeNavMixin::chooseActivity()"}   # Activity
+  - ReplaceBytes:
+      Base:           "BrowseKoboWidget::BrowseKoboWidget(QWidget*)"
+      Offset:         206
+      FindInstBLX:    {SymPLT: "N3DeviceCharm::shopName()"}   # "Shop Kobo" or "Walmart"
+      ReplaceInstBLX: {SymPLT: "N3DeviceCharm::extrasName()"} # "Activity"
+  - ReplaceBytes:
+      Base:          "HomePageView::setOverDriveUser(OverDriveUser const&)"
+      Offset:         114
+      FindInstBLX:    {SymPLT: "GenericHomeWidget::setMetaText(QString)"} # "OverDrive"
+      ReplaceInstNOP: true
+
+###
+
+### Smartlink patches ###
+
+Set visible SmartLink:
+  - Enabled: no
+  - PatchGroup: SmartLink
+  - Description: Sets the currently visible smartlink (does not override priority messages).
+  # SmartLinks: (name from SmartLinkWidget::getAnalyticsMessage)
+  #  # - internal name   - default condition                                   - what                                                             - action
+  # PRIORITY MESSAGES (shown first up to 3 times each): (SmartLinkWidget::showPriorityMessage, ActivityManager::smartLinkPriorityMessage, SmartLinkWidget::tapped)
+  #  5 - ReleaseNotes    - whats new available from Activity                   - RELEASE NOTES: Find out what's new in this software update       - whats new (from Activity)
+  #  6 - OverDriveFTE    - overdrive enabled && not signed in                  - OVERDRIVE: Learn how to borrow eBooks from your public library   - overdrive about
+  #  7 - KoboPlusFTE     - kobo plus enabled && not subscribed                 - KOBO PLUS: Browse Kobo Plus books                                - kobo store -> kobo plus
+  #  8 - OverDrive       - overdrive enabled && signed in && have hold         - OVERDRIVE: View your public library holds                        - overdrive holds list
+  # ROTATION MESSAGES (randomly chosen): (SmartLinkWidget::showRotationMessage, ActivityManager::smartLinkGeneralMessage, SmartLinkWidget::tapped)
+  #  1 - Pocket          - pocket not signed in                                - POCKET: Read articles from the web on your eReader                - pocket about
+  #  2 - KoboPlus        - kobo plus enabled && not subscribed                 - KOBO PLUS: Upgrade to a Kobo Plus Read & Listen subscription      - kobo store -> kobo plus
+  #  2 - KoboPlus        - kobo plus enabled && not subscribed                 - KOBO PLUS: Read as much as you want with a Kobo Plus subscription - kobo store -> kobo plus
+  #  3 - Overdrive       - overdrive enabled && not signed in                  - OVERDRIVE: Borrow eBooks from your public library                 - overdrive about
+  #  4 - Categories      - always                                              - CATEGORIES: Browse fiction, romance, biography and more           - kobo store -> categories
+  #  9 - NaturalLight    - has light sensor && not viewed tutorial             - DEVICE NAME: Learn about the Natural Light feature                - rgb front light about
+  # 10 - QuickTour       - quick tour not shown && quick turn tile not visible - GETTING STARTED: Get to know your %0                              - quick tour
+  # 11 - ReadingTour     - read a book tour not showed                         - READING A BOOK: Get quick tips about reading on your eReader      - read a book tutorial
+  # 12 - UserGuide       - user guide present && not opened                    - USER GUIDE: Read the user guide for your %0                       - read -> user guide
+  # 13 - RelatedReads    - recent book available from Activity                 - RELATED READS: Discover books related to the ones you're reading  - browse -> similar books
+  # 14 - Wishlist        - no wishlist items || something else                 - WISHLIST: Create a Wishlist of books you're interested in         - browse -> wishlist
+  # 15 - ReadingSettings - reading settings not changed                        - READING SETTINGS: Customize the way you read a book               - settings -> reading settings
+  # 16 - ReadingStats    - books finished > 0 && hours read rounded to .5 > 0  - READING STATS: You've finished %n books and read for %n hours     - reading life -> stats
+  # 17 - SuperPoints     - participating in super points && points > 2400      - KOBO SUPER POINTS: You have %0 Super Points to redeem             - kobo store
+  # 18 - PocketUser      - unread pocket articles > 0                          - POCKET: Catch up on the %n article(s) you added recently          - library -> pocket
+  # 19 - Audiobooks      - supports audiobooks && audiobooks enabled           - AUDIOBOOKS: Get started with Audiobooks on your eReader           - kobo store -> audiobooks
+  #
+  - BaseAddress:  {Sym: "SmartLinkWidget::showRotationMessage(Device const&)", Rel: 20}
+  - ReplaceBytes: {FindInstBLX: {SymPLT: "ActivityManager::smartLinkGeneralMessage(Device const&)"}, ReplaceH: 4F F0 04 00} # MOV.W r0, #4
+  # set the new SmartLink to show (you can set this to your preference based on
+  # the list above, but it MUST be one of the above options, or you may need
+  # to factory reset):
+  - ReplaceInt:   {Offset: 2, Find: 4, Replace: 4}
+
+Only show Pocket SmartLink:
+  - Enabled: no
+  - PatchGroup: SmartLink
+  - Description: Only show the Pocket SmartLink on the home screen.
+  - ReplaceBytes:
+      Base:        "SmartLinkWidget::showRotationMessage(Device const&)"
+      Offset:      20
+      FindInstBLX: {SymPLT: "ActivityManager::smartLinkGeneralMessage(Device const&)"}
+      ReplaceH:    4F F0 12 00
+  # replace the text (choose one, or remove both):
+  - FindReplaceString: {Find: "Catch up on the %n article(s) you added recently", Replace: "My Articles"}
+# - FindReplaceString: {Find: "Catch up on the %n article(s) you added recently", Replace: "My Articles (%n unread)"}
+
+Only show stats SmartLink:
+  - Enabled: no
+  - PatchGroup: SmartLink
+  - Description: Only show the stats SmartLink on the home screen.
+  - ReplaceBytes:
+      Base:        "SmartLinkWidget::showRotationMessage(Device const&)"
+      Offset:      20
+      FindInstBLX: {SymPLT: "ActivityManager::smartLinkGeneralMessage(Device const&)"}
+      ReplaceH:    4F F0 10 00
+
+Never show Kobo Plus, wishlist, and points SmartLinks:
+  - Enabled: no
+  - PatchGroup: SmartLink
+  - Description: Removes Kobo Plus, wishlist, and points SmartLinks from the rotation.
+  - BaseAddress: "ActivityManager::smartLinkGeneralMessage(Device const&)"
+  # NOP Kobo Plus (2):
+  - ReplaceBytes: {Offset: 310, FindH: 02 23, CheckOnly: true} # MOVS r3, #2
+  - ReplaceBytes: {Offset: 320, FindInstBLX: {SymPLT: "QVector<SmartLinkType>::append(SmartLinkType const&)"}, ReplaceInstNOP: true}
+  # NOP wishlist (14):
+  - ReplaceBytes: {Offset: 284, FindH: 0E 23, CheckOnly: true} # MOVS r3, #14
+  - ReplaceBytes: {Offset: 294, FindInstBLX: {SymPLT: "QVector<SmartLinkType>::append(SmartLinkType const&)"}, ReplaceInstNOP: true}
+  # NOP super points (17):
+  - ReplaceBytes: {Offset: 1514, FindH: 11 23, CheckOnly: true} # MOVS r3, #17
+  - ReplaceBytes: {Offset: 1526, FindInstBLX: {SymPLT: "QVector<SmartLinkType>::append(SmartLinkType const&)"}, ReplaceInstNOP: true}
+
+###
+
+# Note: The "Increase TOC level indentation" and "Increase TOC level indentation
+# and fix extra indentation bug" patches are not necessary anymore in firmware
+# 4.24.15672+ and have been removed since the fixes have been integrated into
+# the original firmware. The default indentation is now around 3x larger than it
+# was before (and it scales for each device), and the firmware will always
+# subtract 1 from the depth before applying the indentation (since it's indexed
+# from 1+ rather than 0+).
+#
+# If you are not happy with the new defaults, see the new "Change TOC level
+# indentation" patch in nickel.yaml.
+
+Allow showing info panel on random screensaver:
+  - Enabled: no
+  - Description: |
+      See https://www.mobileread.com/forums/showthread.php?t=321609. This patch
+      allows showing the info panel even when using a random screensaver image
+      from .kobo/screensaver (note that full-screen covers needs to be enabled
+      for the screensaver to show).
+  - ReplaceBytes:
+      Base: "PowerViewController::updateCover()"
+      Offset: 252
+      FindInstBLX: {SymPLT: "BookCoverDragonPowerView::setInfoPanelVisible(bool)"}
+      ReplaceInstNOP: true
+
+Remove title from reading header/footer:
+  - Enabled: no
+  - Description: Removes the chapter/book title from the new reading header/footer.
+  # In the longest form of ReadingFooter::update (the others are wrappers with
+  # the args being set to the current value), the first one is the title. The
+  # final string is created by starting with the title, then appending the "-",
+  # then the page number / percentage / etc text.
+  #
+  # This one is slightly unusual in that the reading header also shares the
+  # ReadingFooter code (ReadingView::updateProgressHeader only has the page
+  # text, and it ends with a branch to ReadingFooter::update). This means we
+  # only have to patch one place, but it also means you can't have the title in
+  # one, but not the other.
+  #
+  # We'll patch this in a slightly hacky and inefficient, but simple and
+  # easy-to-update way by replacing the first QString::append (the dash) with a
+  # QString::resize to zero (I would have done a QString::clear, but that symbol
+  # isn't imported):
+  - BaseAddress:  {Sym: "ReadingFooter::update(QString const&, QString const&, QString const&, bool)", Rel: 190}
+  - ReplaceBytes: {Offset: 0, FindH: 49 46, ReplaceH: 00 21} # replace MOV r1, sb with MOV r1, #0 (the MOV doesn't matter, but may to be updated to match, ensuring nothing after depends on it)
+  - ReplaceBytes: {Offset: 4, FindInstBLX: {SymPLT: "QString::append(QString const&)"}, ReplaceInstBLX: {SymPLT: "QString::resize(int)"}}
+
+# Prevent Kobo from scanning dotfiles/folders (since 4.17.13651): See https://www.mobileread.com/forums/showthread.php?t=323083.
+
+Larger Sleep/Power-off timeouts:
+  - Enabled: no
+  - PatchGroup: Sleep/Power-off timeouts
+  - Description: |
+      Increase the available sleep/power-off timeouts to larger values (up to a
+      few weeks). To customize this patch, see https://pgaskin.net/kobopatch-patches/lgrpwroff-21533.html .
+
+      IMPORTANT - Although this patch has been tested by multiple users and
+      confirmed to be working, the interaction between the RTC timer and Nickel
+      has many moving parts. As reported by JSWolf on MR, this patch might have
+      issues with actually powering-off with timeouts longer than a day. The
+      cause is likely to be the auto-sync interval or sleepcover causing the
+      timer to be overridden/reset every day. Nevertheless, this patch should
+      work reliably for timeouts under 12 hours, and probably under 1 day.
+
+      If you are using this patch with timeouts above 12 hours, and can confirm
+      if it works/doesn't work, please PM me or comment on GitHub with your
+      setting values, sleepcover or not, auto-sync interval, wifi on/off, firmware
+      version, and Kobo model.
+
+      See https://github.com/pgaskin/kobopatch-patches/issues/28#issuecomment-537161827
+      for more details about this.
+  # Multipliers
+  - ReplaceBytes:
+      Base: "N3PowerWorkflowManager::configureWakeup(AlarmControl*, int, AlarmControlDelegate*)"
+      Offset: 28
+      FindH: 03 FB 04 F2    # MUL r2(dest), r3(multiplier), r4(mins)
+      ReplaceH: 4F EA C4 42 # LSL r2, r4, #19
+  - ReplaceBytes: {Base: "N3PowerWorkflowManager::pollBattery()", Offset: 106, FindH: 08 FB 00 F8, ReplaceH: 4F EA C0 48} # MUL r8(dest), r8(multiplier), r0(mins) -> LSL r8, r0, #19
+  - ReplaceBytes: {Base: "N3PowerWorkflowManager::pollBattery()", Offset: 156, FindH: 02 FB 00 F2, ReplaceH: 4F EA C0 42} # MUL r2(dest), r2(multiplier), r0(mins) -> LSL r2, r0, #19
+  # Menu text
+  - FindBaseAddressString: "5 mins\0"
+  - ReplaceString: {Offset:  0, Find: "5 mins\0", Replace: "8m"}
+  - ReplaceString: {Offset:  8, Find: "10 mins",  Replace: "34m"}
+  - ReplaceString: {Offset: 16, Find: "15 mins",  Replace: "1h1m"}
+  - ReplaceString: {Offset: 24, Find: "30 mins",  Replace: "4h4m"}
+  - ReplaceString: {Offset: 32, Find: "45 mins",  Replace: "12h5m"}
+  - ReplaceString: {Offset: 38, Find: "60 mins",  Replace: "24h1m"}
+  # Values (see https://www.mobileread.com/forums/showpost.php?p=3887105)
+  - BaseAddress: "N3SettingsPowerView::initChoices()"
+  - ReplaceInt: {Offset:  56, Find:  5, Replace:   1}
+  - ReplaceInt: {Offset: 118, Find: 10, Replace:   4}
+  - ReplaceInt: {Offset: 180, Find: 15, Replace:   7}
+  - ReplaceInt: {Offset: 240, Find: 30, Replace:  28}
+  - ReplaceInt: {Offset: 300, Find: 45, Replace:  83}
+  - ReplaceInt: {Offset: 360, Find: 60, Replace: 165}
+
+# TODO(geek1011): Allow rotation on all devices
+
+Don't uppercase header/footer text:
+  - Enabled: no
+  - Description: Prevents the text in the reader header/footer from being uppercased.
+  - PatchGroup: Header/footer page number text
+  # Replace QString::toUpper call with QString::trimmed (to copy the string, and
+  # not need to add a mov instruction and NOP the destructor):
+  - ReplaceBytes:
+      Base:            "ReadingView::getChapterTitle()"
+      Offset:          298
+      FindInstBLX:     {SymPLT: "QString::toUpper() const"}
+      ReplaceInstBLX:  {SymPLT: "QString::trimmed() const"}
+  - ReplaceBytes:
+      Base:            "ReadingView::updateFooter()"
+      Offset:          26
+      FindInstBLX:     {SymPLT: "QString::toUpper() const"}
+      ReplaceInstBLX:  {SymPLT: "QString::trimmed() const"}
+  # Page number text:
+  - FindReplaceString: {Find: "%1 OF %2", Replace: "%1 of %2"}
+  # Percent read text (this string is only used by ReadingView::getChapterPercentProgressText,
+  # and the home screen one is already lowercase):
+  - FindReplaceString: {Find: "%1% READ", Replace: "%1% read"}
+
+Custom header/footer page number text:
+  - Enabled: no
+  - PatchGroup: Header/footer page number text
+  - Description: Changes the page number text format in the reading header & footer
+  - FindReplaceString: {Find: "%1 OF %2", Replace: "%1 / %2"}
+
+Don't uppercase header/footer text and change page number text:
+  - Enabled: no
+  - Description: Combines the previous two patches.
+  - PatchGroup: Header/footer page number text
+  - ReplaceBytes:
+      Base:            "ReadingView::getChapterTitle()"
+      Offset:          298
+      FindInstBLX:     {SymPLT: "QString::toUpper() const"}
+      ReplaceInstBLX:  {SymPLT: "QString::trimmed() const"}
+  - ReplaceBytes:
+      Base:            "ReadingView::updateFooter()"
+      Offset:          26
+      FindInstBLX:     {SymPLT: "QString::toUpper() const"}
+      ReplaceInstBLX:  {SymPLT: "QString::trimmed() const"}
+  - FindReplaceString: {Find: "%1 OF %2", Replace: "%1 / %2"}
+  - FindReplaceString: {Find: "%1% READ", Replace: "%1% read"}
+
+Swap reading header/footer:
+  - Enabled: no
+  - Description: |
+      Swaps the reading header/footer text (i.e. book progress on top, chapter
+      progress on the bottom). This patch has undefined behaviour if the header
+      or footer is disabled.
+  # Both the header and footer use the ReadingFooter class and update them using
+  # the overloaded ReadingFooter::update function. The difference is which r0 (this)
+  # is passed to them. Since tbe header and footer are both members of ReadingView,
+  # and they are loaded just before the update (and aren't used otherwise), they
+  # can be swapped by switching the struct offset used by LDR.
+  #
+  # Offsets (since 4.19.14123):
+  #  - ReadingView->header - 0x10
+  #  - ReadingView->footer - 0x1C
+  - ReplaceBytes:
+      Base:     "ReadingView::updateProgressHeader(QString const&, QString const&)"
+      Offset:   8
+      FindH:    00 69 # LDR r0, [r0, #0x10]
+      ReplaceH: C0 69 # LDR r0, [r0, #0x1C]
+  - ReplaceBytes:
+      Base:     "ReadingView::updatePercentageFooter(QString const&)"
+      Offset:   182
+      FindH:    C0 69 # LDR r0, [r0, #0x1C]
+      ReplaceH: 00 69 # LDR r0, [r0, #0x10]
+  - ReplaceBytes:
+      Base:     "ReadingView::updatePercentageFooter(QString const&)"
+      Offset:   296
+      FindH:    C0 69 # LDR r0, [r0, #0x1C]
+      ReplaceH: 00 69 # LDR r0, [r0, #0x10]
+  - ReplaceBytes:
+      Base:     "ReadingView::updatePageFooter(QString const&)"
+      Offset:   172
+      FindH:    C0 69 # LDR r0, [r0, #0x1C]
+      ReplaceH: 00 69 # LDR r0, [r0, #0x10]
+  - ReplaceBytes:
+      Base:     "ReadingView::updateTimeFooter(QString const&)"
+      Offset:   50 # "Loading..."
+      FindH:    E4 69 # LDR r4, [r4, #0x1C]
+      ReplaceH: 24 69 # LDR r4, [r4, #0x10]
+  - ReplaceBytes:
+      Base:     "ReadingView::updateTimeFooter(QString const&)"
+      Offset:   102 # time estimate
+      FindH:    D3 F8 1C 90 # LDR.W sb, [r3, #0x1C]
+      ReplaceH: D3 F8 10 90 # LDR.W sb, [r3, #0x10]
+  - ReplaceBytes:
+      Base:     "ReadingView::updateTimeFooter(QString const&)"
+      Offset:   240 # pages
+      FindH:    DE F8 1C 40 # LDR.W r4, [lr, #0x1C]
+      ReplaceH: DE F8 10 40 # LDR.W r4, [lr, #0x10]
+
+# Note: The "Enable advanced settings for all fonts" patch is no longer
+# necessary since the advanced font settings are now available for all fonts.
+
+# TODO(geek1011): Customize ComfortLight settings
+Customize ComfortLight settings:
+  - Enabled: no
+  - Description: |
+      Change the times available in the ComfortLight bedtime dropdown and the
+      start/end times for the color changes. All values in this patch are
+      customizable.
+
+      The default values for this patch give you 21 options between 5PM and 3AM
+      at 30 minute intervals, with the colour change starting at 4PM, and the
+      change back to blue between 5AM and 7AM. The firmware default is 13 options
+      between 9PM-3AM at 30 minute intervals, with the transition starting at 6PM.
+  ##
+  # In an unnamed subroutine two layers into FrontLightPopupController::loadView
+  # (find it by going back from QTime::addSecs), the times for the dropdown are
+  # generated into a QVector<QPair<QString, QTime>> with a simple loop.
+  - BaseAddress: 0xE8629C # find the base of the unnamed subroutine with the x-ref to _ZN5QTimeC1Eiiii
+  #
+  # Change the initial hour / first bedtime dropdown item passed to the QTime
+  # constructor (mov r1, #21):
+  - ReplaceInt: {Offset: 22, Find: 21, Replace: 17} # 21:00 (9PM) -> 17:00 (5PM)
+  #
+  # Optional: Change the increment passed to QTime::addSecs (you need to use an
+  # ARM assembler to change this value):
+  - ReplaceBytes: {Offset: 122, FindH: 4F F4 E1 61, ReplaceH: 4F F4 E1 61} # mov.w r1, #1800: 30m
+  #
+  # Change the number of increments / bedtime dropdown options (start at the
+  # initial time, add this number -1 more items with the above increment each
+  # time) (movs r5, #13):
+  - ReplaceInt: {Offset: 78, Find: 13, Replace: 21} # 13 [9PM..3AM]+30m -> 21 [5PM..3AM]+30m
+  #
+  # Change the number of pre-allocated elements (I don't think this is actually
+  # required, as Qt will realloc as necessary, but we might as well do this just
+  # in case) (mov r1, #21):
+  - ReplaceInt: {Offset: 696, Find: 13, Replace: 21} # same as prev replacement
+  ##
+  # The actual color adjustment is done in BedtimeManager::adjustTemperature.
+  # The color temperature is based on the current time, the bedtime, the hardcoded
+  # sunset, the hardcoded sunrise start, the hardcoded sunrise end, the daytime
+  # temperature, and the nighttime temperature.
+  - BaseAddress: "BedtimeManager::adjustTemperature()"
+  #
+  # Change the sunset time (the transition to a warmer temperature starts here
+  # and transitions until the bedtime chosen) (this should be 1-3 hours before
+  # the minimum bedtime from the first replacement above) (mov r1, #18):
+  - ReplaceInt: {Offset: 228, Find: 18, Replace: 16} # 18:00 (9PM-3=6PM) -> 16:00 (5PM-1=4PM)
+  #
+  # Change the time for the sunset timer to fire at (this is passed to a QTime
+  # constructor which is passed to PowerTime::fireAt) (mov r1, #18):
+  - ReplaceInt: {Offset: 508, Find: 18, Replace: 16} # should match the sunset time above
+  #
+  # Optional: Change the sunrise start time (the transition back to a cooler
+  # temperature starts here) (this should be sometime after the last bedtime,
+  # but before the sunset time) (mov r1, #5):
+  - ReplaceInt: {Offset: 262, Find: 5, Replace: 5} # 5AM
+  #
+  # Optional: Change the sunrise end time (the transition back to a cooler
+  # temperature ends here) (this should be 1-3 hours after the sunrise start but
+  # before the sunset time or bad things will happen with negative values) (mov r1, #7):
+  - ReplaceInt: {Offset: 208, Find: 7, Replace: 7} # 5AM+2=7AM
+
+# The following patches allow you to enable a config file option with a patch.
+
+FeatureSettings - BookSpecificStats:
+  - Enabled: no
+  - Description: Adds an option to view stats for a specific book to the book menu.
+  - ReplaceBytes: {Base: "FeatureSettings::bookSpecificStatsEnabled()", Offset: 54, FindInstBLX: {SymPLT: "QVariant::toBool() const"}, ReplaceH: 4F F0 01 00}
+
+FeatureSettings - ShowFacebookShare:
+  - Enabled: no
+  - Description: Re-enables the Facebook share option in menus.
+  - ReplaceBytes: {Base: "FeatureSettings::showFacebookShare()", Offset: 54, FindInstBLX: {SymPLT: "QVariant::toBool() const"}, ReplaceH: 4F F0 01 00}
+
+FeatureSettings - FullScreenBrowser:
+  - Enabled: no
+  - Description: Makes the browser fullscreen (note that there is no way out except for rebooting).
+  - ReplaceBytes: {Base: "FeatureSettings::fullScreenBrowser()", Offset: 54, FindInstBLX: {SymPLT: "QVariant::toBool() const"}, ReplaceH: 4F F0 01 00}
+
+FeatureSettings - MyWords:
+  - Enabled: no
+  - Description: Enables the My Words tab of the Activity screen.
+  - ReplaceBytes: {Base: "FeatureSettings::myWords()", Offset: 54, FindInstBLX: {SymPLT: "QVariant::toBool() const"}, ReplaceH: 4F F0 01 00}
+
+FeatureSettings - ExportHighlights:
+  - Enabled: no
+  - Description: Add an option to export highlights to the book menu.
+  - ReplaceBytes: {Base: "FeatureSettings::exportHighlightsEnabled()", Offset: 54, FindInstBLX: {SymPLT: "QVariant::toBool() const"}, ReplaceH: 4F F0 01 00}
+
+DeveloperSettings - AutoUsbGadget:
+  - Enabled: no
+  - Description: Automatically enable USB Storage mode when connected.
+  - ReplaceBytes: {Base: "DevSettings::autoUsbGadget()", Offset: 54, FindInstBLX: {SymPLT: "QVariant::toBool() const"}, ReplaceH: 4F F0 01 00}
+
+PowerSettings - UnlockEnabled:
+  - Enabled: no
+  - Description: Disables/enables the slide to unlock feature.
+  - ReplaceBytes: {Base: "PowerSettings::getUnlockEnabled()", Offset: 120, FindInstBLX: {SymPLT: "QVariant::toBool() const"}, ReplaceH: 4F F0 00 00} # disable
+# - ReplaceBytes: {Base: "PowerSettings::getUnlockEnabled()", Offset: 120, FindInstBLX: {SymPLT: "QVariant::toBool() const"}, ReplaceH: 4F F0 01 00} # enable

--- a/src/versions/4.40.23081/libnickel.so.1.0.0.yaml/sherman.yaml
+++ b/src/versions/4.40.23081/libnickel.so.1.0.0.yaml/sherman.yaml
@@ -1,0 +1,34 @@
+# The following patch(es) were made by sherman
+
+Unify font sizes:
+  - Enabled: no
+  - Description: |
+      Attempt to unify the font sizes between epub and kepub. Without this patch
+      epub font sizes can be much larger than kepub at the same size setting.
+    # From my current understanding, the final font size for epubs is calculated
+    # as follows: ( font_size / scale_factor ) * DPI, where 'scale_factor' =
+    # 25.0. It seems RMSDK must be handling DPI elsewhere however, because the
+    # DPI multiplication here seems to have a detrimental effect, and behaves
+    # differently on different devices. This patch changes the 'scale_factor' to
+    # 2.5, and replaces the call to get DPI with a constant multiplier (16).
+    # The results of using these values are equivalent to  
+    # ( font_size / 15.0 ) * 96 which is what I suspect the kepub formula is.
+    # Note, that the replacement values are limited to 0.25 - 31.0 in 0.25
+    # increments.
+    #
+    # Refer to https://github.com/pgaskin/kobopatch-patches/issues/96 for more
+    # information.
+  # EPUB settings:
+  - BaseAddress:
+      Sym: "AdobeStyling::update(QString const&)"
+      Rel: 5796 # at ReadingSettings::getReadingFontSizeScaleFactor(float, float)
+  # Set the scale factor to 2.5
+  - ReplaceBytes:
+      Offset:   -20
+      FindH:    F3 EE 09 0A # vmov.f32 s1, #25.0
+      ReplaceH: F0 EE 04 0A # vmov.f32 s1, #2.5
+  # Replace QScreen::logicalDotsPerInchX() with our own multiplier of 16.0
+  - ReplaceBytes:
+      Offset:      26
+      FindInstBLX: {SymPLT: "QScreen::logicalDotsPerInchX() const"}
+      ReplaceH:    B3 EE 00 0B # vmov.f64 d0, #16.0

--- a/src/versions/4.40.23081/librmsdk.so.1.0.0.yaml/geoffr.yaml
+++ b/src/versions/4.40.23081/librmsdk.so.1.0.0.yaml/geoffr.yaml
@@ -1,0 +1,147 @@
+# The following patch(es) are ported from GeoffR's patch zips
+
+Disable orphans/widows avoidance:
+  - Enabled: no
+  - Description: Enable this patch to avoid blank lines at the bottom of pages in ePub books.
+    # The default values of orphans:2; widows:2; cause extra blank lines to be added
+    # to some pages to avoid leaving isolated lines of a paragraph at the top or
+    # bottom of a page. Enabling this patch effectively forces orphans:1; widows:1;,
+    # overriding the defaults and the book's stylesheet.
+    #
+    # Beware that this patch might(?) intefere with related CSS properties such as
+    # page-break-after:avoid; or page-break-inside:avoid;. A better solution would
+    # be to edit the book's stylesheet to set orphans:1; widows:1;.
+  - ReplaceBytes:
+      Base:     "_ZN6layout13FlowProcessor17getPageBreakScoreEbbbbf"
+      Offset:   80
+      FindH:    E6 D0
+      ReplaceH: E6 E7
+
+Default ePub serif font:
+  - Enabled: no
+  - Description: |
+        This patch changes the default ePub serif font to Bitter.
+        If the book's stylesheet specifies the generic 'font-family:serif;' then
+            the ePub reader will try to use the built-in GUI system serif font
+                (Georgia or 'Rakuten Serif').
+            This is also the font you see if you select 'Publisher Default' from
+            the Kobo [Aa] menu and your epub has not specified any particular font.
+        This patch allows you to change the default to a different serif font 
+            (built-in or sideloaded).
+        N.B. This patch does not affect kepubs.
+
+    # fw 4.32.19501: The font-family name in Replace: must now be the WHOLE name
+    #                not just the first few characters of the name.
+    #
+    # To use a different font, change "Bitter" in each replacement string
+    # to another font name (15 characters max).
+    # For example, change "Rakuten%20Serif" to "Noto%20Serif" to use 
+    #   a sideloaded 'Noto Serif' font.
+    # The 3-char string, %20, represents a single space in the font-family name.
+    #
+    # If your new font name is longer than 15 chars you would need to:
+    #   - Use a font editor to shorten the internal font-family name to <= 15 chars
+    #   - Rename the 4 font filenames to match the new shortened name
+    #   - Copy the 4 renamed font files into the Kobo sideloaded fonts folder
+  - FindReplaceString: {Find: "/normal/Rakuten%20Serif", Replace: "/normal/Bitter"}
+  - FindReplaceString: {Find: "/bold/Rakuten%20Serif", Replace: "/bold/Bitter"}
+  - FindReplaceString: {Find: "/italic/Rakuten%20Serif", Replace: "/italic/Bitter"}
+  - FindReplaceString: {Find: "/bolditalic/Rakuten%20Serif", Replace: "/bolditalic/Bitter"}
+
+Default ePub sans-serif font:
+  - Enabled: no
+  - Description: |
+      This patch changes the default ePub sans-serif font to 'Noto Sans'.
+      If the book's stylesheet specifies the generic 'font-family:sans-serif;' then
+        the ePub reader will try to use the built-in GUI system sans-serif font 
+        ('Avenir Next' or 'Rakuten Sans').
+      This patch allows you to change the default to a different sans-serif font
+        (built-in or sideloaded).
+      N.B. This patch does not affect kepubs.
+
+    # fw 4.32.19501: The font-family name in Replace: must now be the WHOLE name
+    #                not just the first few characters of the name.
+    # fw 4.34.20097: Kobo removed the 'Gill Sans' font files from the firmware. There is
+    #       no longer a built-in sans-serif font with a name short enough to use in this patch.
+    #       You can still use the patch with one of your sideloaded sans-serif fonts.
+    # fw 4.34+: Kobo continue to revise the list of built-in fonts included in the firmware.
+    #
+    # To use a different font, change "Noto%20Sans" in each Replace: string
+    #   to another font name (14 characters max).
+    # For example, change "Noto%20Sans" to "Trebuchet" to use a sideloaded Trebuchet font.
+    # The 3-char string, %20, represents a single space in the font-family name.
+    #
+    # If your new font name is longer than 14 chars you would need to:
+    #   - Use a font editor to shorten the internal font-family name to <= 14 chars
+    #   - Rename the 4 font filenames to match the new shortened name
+    #   - Copy the 4 renamed font files into the Kobo sideloaded fonts folder
+  - FindReplaceString: {Find: "/normal/Rakuten%20Sans", Replace: "/normal/Noto%20Sans"}
+  - FindReplaceString: {Find: "/bold/Rakuten%20Sans", Replace: "/bold/Noto%20Sans"}
+  - FindReplaceString: {Find: "/italic/Rakuten%20Sans", Replace: "/italic/Noto%20Sans"}
+  - FindReplaceString: {Find: "/bolditalic/Rakuten%20Sans", Replace: "/bolditalic/Noto%20Sans"}
+
+Force user line spacing in ePubs (Part 2 of 2):
+  - Enabled: no
+  - Description: |
+      This is part 2 of 2. Also enable part 1 in libnickel.so.1.0.0.patch
+      This patch prevents any line-height style set in the book's stylesheet from
+      being recognised. It will spoil the formatting of some books, but will ensure
+      that the line spacing set with the adjustment slider takes effect. (Unless
+      the publisher has used the font shorthand style; see option below.)
+  - FindBaseAddressString: "\0line-height\0"
+  - ReplaceString: {Offset: 1, Find: "l", Replace: "_"}
+    # Uncomment the following two lines to also prevent the font shorthand style
+    # from being recognised. The font shorthand style is not very common in ePubs,
+    # but where used it can also prevent the line spacing from being adjusted.
+    # Beware that this option will likely have much bigger side-effects on the
+    # book's formatting, because the font shorthand style is used to set the
+    # font-size, font family, and other styles in addition to line-height.
+# - ReplaceString: {Offset: 1, Find: "f", Replace: "_"}
+# - FindBaseAddressString: "\0font\0"
+
+Force user font-family in ePubs (Part 2 of 2):
+  - Enabled: no
+  - Description: |
+      This is part 2 of 2. Also enable part 1 in libnickel.so.1.0.0.patch
+      This patch prevents any font-family style set in the book's stylesheet from
+      being recognised. It might spoil the style of books which use multiple fonts,
+      but will ensure that the font-family set from the device menu takes effect.
+      (Unless the publisher has used the font shorthand style; see option below.)
+  - FindBaseAddressString: "\0font-family\0"
+  - ReplaceString: {Offset: 1, Find: "f", Replace: "_"}
+    # Uncomment the following two lines to also prevent the font shorthand style
+    # from being recognised. The font shorthand style is not very common in ePubs,
+    # but where used it can also prevent the font-family from being adjusted.
+    # Beware that this option will likely have much bigger side-effects on those
+    # book's formatting, because the font shorthand style is used to set the
+    # font-size, line-height, and other styles in addition to font-family.
+# - ReplaceString: {Offset: 1, Find: "f", Replace: "_"}
+# - FindBaseAddressString: "\0font\0"
+
+Ignore ePub book Adobe XPGT stylesheet (page-template.xpgt):
+  - Enabled: no
+  - Description: |
+      Not all ePubs have an Adobe XPGT stylesheet, and the ones that do often use
+      it mainly to set the page margins. Unfortunately those margins are added to
+      the page margins set via @page in the CSS stylesheet, and cannot be overidden
+      by the `ePub fixed/ajustable top/bottom margins` patch.
+      This patch should cause any Adobe XPGT stylesheet in the book to be ignored,
+      but for the book's CSS stylesheet still to be used as normal.
+      (You might prefer to remove the margins from the book's XPGT stylesheet
+      before sideloading, instead of using this patch. Calibre's Modify ePub plugin
+      has a useful option for doing this.)
+  - FindBaseAddressString: "\0template\0"
+  - ReplaceString: {Offset: 1, Find: "t", Replace: "_"}
+
+# The following two patches will not be useful to most people, don't enable them unless you are sure you need them.
+Ignore ePub book CSS and Adobe XPGT stylesheets:
+  - Enabled: no
+  - FindBaseAddressString: "\0stylesheet\0"
+  - ReplaceString: {Offset: 1, Find: "s", Replace: "_"}
+  - FindBaseAddressString: "\0style-sheet\0"
+  - ReplaceString: {Offset: 1, Find: "s", Replace: "_"}
+
+Ignore ePub TOC navpoints:
+  - Enabled: no
+  - FindBaseAddressString: "\0navPoint\0"
+  - ReplaceString: {Offset: 1, Find: "n", Replace: "_"}

--- a/src/versions/4.40.23081/librmsdk.so.1.0.0.yaml/jackie_w.yaml
+++ b/src/versions/4.40.23081/librmsdk.so.1.0.0.yaml/jackie_w.yaml
@@ -1,0 +1,26 @@
+# The following patches are by jackie_w.
+
+Default ePub monospace font:
+  - Enabled: no
+  - Description: |
+      Updated for fw 4.19.14123:
+      The Kobo firmware doesn't include a monospace font, you need to sideload one.
+      If the book's stylesheet specifies the generic font-family:monospace;
+        then the ePub reader will try to use the 'Courier' font.
+      N.B. This patch does not affect kepubs.
+
+    # fw 4.32.19501: A font whose name begins with 'Courier' e.g. 'Courier Prime'
+    #    will no longer be recognised as the default monospace font for epub.
+    #    The font-family name must now be exactly 'Courier'.
+    # You do not need this patch if you have already installed a font
+    #    named 'Courier' in the Kobo sideloaded fonts folder. 
+    # The only users who might want this patch are those whose preferred 
+    #    sideloaded monospace font has a name other than 'Courier' and whose
+    #    font-family name is <= 7 characters.
+    #
+    # To use a different font, change 'Courier' in each of the Replace: strings
+    # to another sideloaded font name (7 characters max).
+  - FindReplaceString: {Find: "/normal/Courier", Replace: "/normal/Courier"}
+  - FindReplaceString: {Find: "/bold/Courier", Replace: "/bold/Courier"}
+  - FindReplaceString: {Find: "/italic/Courier", Replace: "/italic/Courier"}
+  - FindReplaceString: {Find: "/bolditalic/Courier", Replace: "/bolditalic/Courier"}

--- a/src/versions/4.40.23081/nickel.yaml/geoffr.yaml
+++ b/src/versions/4.40.23081/nickel.yaml/geoffr.yaml
@@ -1,0 +1,79 @@
+# The following patch(es) are ported from GeoffR's patch zips
+
+Reduce top/bottom page spacer:
+  - Enabled: no
+  - Description: |
+      Reduces the blank space that remains at the top/bottom of the page when
+      the "Chapter progress" / "Book progress" reading settings options are set to Off.
+      Spacer height is halved, customise by changing the min-height + max-height
+      values in the Replace lines below. Affects both ePub and KePub books.
+  - FindZlib: "MediumVertSpacer" # default.qss
+  - ReplaceZlibGroup:
+      Replacements:
+      # Touch/Mini: 24px --> 12px
+      - Find:    "MediumVertSpacer[qApp_deviceIsTrilogy=true] {\n  min-height: 24px;\n  max-height: 24px;\n}"
+        Replace: "MediumVertSpacer[qApp_deviceIsTrilogy=true] {\n  min-height: 12px;\n  max-height: 12px;\n}"
+      # Glo/Aura/Aura2ed: 32px --> 16px
+      - Find:    "MediumVertSpacer[qApp_deviceIsPhoenix=true] {\n  min-height: 32px;\n  max-height: 32px;\n}"
+        Replace: "MediumVertSpacer[qApp_deviceIsPhoenix=true] {\n  min-height: 16px;\n  max-height: 16px;\n}"
+      # AuraHD/H2O/GloHD/ClaraHD/Clara2E: 44px --> 22px
+      - Find:    "MediumVertSpacer[qApp_deviceIsDragon=true] {\n  min-height: 44px;\n  max-height: 44px;\n}"
+        Replace: "MediumVertSpacer[qApp_deviceIsDragon=true] {\n  min-height: 22px;\n  max-height: 22px;\n}"
+      # AuraOne/Forma/Sage/Elipsa/Elipsa2E: 56px --> 28px
+      - Find:    "MediumVertSpacer[qApp_deviceIsDaylight=true] {\n  min-height: 56px;\n  max-height: 56px;\n}"
+        Replace: "MediumVertSpacer[qApp_deviceIsDaylight=true] {\n  min-height: 28px;\n  max-height: 28px;\n}"
+      # LibraH2O/Libra2: 50px --> 25px
+      - Find:    "MediumVertSpacer[qApp_deviceIsStorm=true] {\n  min-height: 50px;\n  max-height: 50px;\n}"
+        Replace: "MediumVertSpacer[qApp_deviceIsStorm=true] {\n  min-height: 25px;\n  max-height: 25px;\n}"
+
+Custom synopsis details line spacing:
+  - Enabled: no
+  - Description: Sets the line spacing for Book details synopsis.
+  - FindZlib: "body[qApp_deviceIsTrilogy=true] {\n  line-height: 1.45em;" # qss/BookDetails.qss
+  - ReplaceZlibGroup:
+      Replacements:
+        # Touch/Mini (Trilogy)
+      - {Find: "line-height: 1.45em;", Replace: "line-height: 1.3em;"}
+        # Glo/Aura/Aura2E (Phoenix)
+      - {Find: "line-height: 1.4em;",  Replace: "line-height: 1.3em;"}
+        # AuraHD/AuraH2O/AuraH2O2/GloHD/ClaraHD/Clara2E (Dragon) and
+        # LibraH2O/Libra2 (Storm) and
+        # AuraOne/Forma/Sage/Elipsa/Elipsa2E (Daylight) 
+      - {Find: "line-height: 1.35em;", Replace: "line-height: 1.3em;"}
+
+Custom synopsis font size:
+  - Enabled: no
+  - Description: Increase synopsis font size
+  - FindZlib: "body[qApp_deviceIsTrilogy=true] {\n  font-size: 19px;" # BookDetails.qss
+  - ReplaceZlibGroup:
+      Replacements:
+      - {Find: "font-size: 19px;", Replace: "font-size: 20px;"} # Touch/Mini (Trilogy)
+      - {Find: "font-size: 23px;", Replace: "font-size: 25px;"} # Glo/Aura/Aura2E/Nia (Phoenix)
+      - {Find: "font-size: 29px;", Replace: "font-size: 32px;"} # AuraHD/AuraH2O/AuraH2O2 (Dragon)
+      - {Find: "font-size: 32px;", Replace: "font-size: 35px;"} # GloHD/ClaraHD/Clara2E (Alyssum/Nova)
+      - {Find: "font-size: 34px;", Replace: "font-size: 37px;"} # LibraH2O/Libra2 (Storm)
+      - {Find: "font-size: 37px;", Replace: "font-size: 40px;"} # AuraONE/Forma/Sage/Elipsa/Elipsa2E (Daylight)
+
+Increase home screen cover size:
+  - Enabled: no
+  - PatchGroup: Home screen layout tweaks
+  - Description: Reduces the home screen margins, allowing larger cover images.
+  - FindZlib: "#row1col2" # HomePageView.qss
+  - ReplaceZlibGroup:
+      Replacements:
+        # Touch/Mini (Trilogy)
+      - {Find: "qproperty-leftMargin: 32px;",  Replace: "qproperty-leftMargin: 16px;"}
+      - {Find: "qproperty-rightMargin: 32px;", Replace: "qproperty-rightMargin: 16px;"}
+        # Glo/Aura/Aura2E/Nia (Phoenix)
+      - {Find: "qproperty-leftMargin: 40px;",  Replace: "qproperty-leftMargin: 16px;"}
+      - {Find: "qproperty-rightMargin: 40px;", Replace: "qproperty-rightMargin: 16px;"}
+        # AuraHD/AuraH2O/AuraH2O2/GloHD/ClaraHD/Clara2E (Dragon)
+      - {Find: "qproperty-leftMargin: 57px;",  Replace: "qproperty-leftMargin: 22px;"}
+      - {Find: "qproperty-rightMargin: 57px;", Replace: "qproperty-rightMargin: 22px;"}
+        # AuraONE/Forma/Sage/Elipsa/Elipsa2E (Daylight)
+      - {Find: "qproperty-leftMargin: 74px;",  Replace: "qproperty-leftMargin: 29px;"}
+      - {Find: "qproperty-rightMargin: 74px;", Replace: "qproperty-rightMargin: 29px;"}
+        # LibraH2O/Libra2 (Storm)
+      - {Find: "qproperty-leftMargin: 67px;",  Replace: "qproperty-leftMargin: 29px;"}
+      - {Find: "qproperty-rightMargin: 67px;", Replace: "qproperty-rightMargin: 29px;"}
+

--- a/src/versions/4.40.23081/nickel.yaml/jackie_w.yaml
+++ b/src/versions/4.40.23081/nickel.yaml/jackie_w.yaml
@@ -1,0 +1,444 @@
+# The following patch(es) are ported from jackie_w's patches
+
+Dictionary pop-up - increase available text area:
+  - Enabled: no
+  - Description: |
+      Increase the area available for dictionary definitions in the dictionary pop-up
+      by reducing some of the excess whitespace used (header, footer, margins).
+      This patch was formerly known as 'Dictionary pop-up frame size increase', but in
+      fw 4.10.11591, Kobo removed access to the code which specifies pop-up frame size.
+      fw 4.12.12111, Kobo removed access to the code which could reduce footer size.
+      fw 4.20.14601  Kobo added new DictionaryViewFooter CSS stream to control footer height again.
+  # Part 1
+  - FindZlib: "#InlineDictionaryView" # qss/InlineDictionaryView.qss
+  - ReplaceZlibGroup:
+      Replacements:
+        # Part 1a: #dictionary - reduce top/left margins
+          # Touch/Mini
+        - Find:    "#dictionary[qApp_deviceIsTrilogy=true] {\n  margin-top: 20px;\n  margin-left: 10px;\n}"
+          Replace: "#dictionary[qApp_deviceIsTrilogy=true] {\n  margin-top: 5px;\n  margin-left: 0px;\n}"
+          # Glo/Aura/Aura2/Nia
+        - Find:    "#dictionary[qApp_deviceIsPhoenix=true] {\n  margin-top: 20px;\n  margin-left: 20px;\n}"
+          Replace: "#dictionary[qApp_deviceIsPhoenix=true] {\n  margin-top: 7px;\n  margin-left: 0px;\n}"
+          # AuraHD/AuraH2O/AuraH2O2/GloHD/ClaraHD/Clara2E/LibraH2O/Libra2
+        - Find:    "#dictionary[qApp_deviceIsDragon=true] {\n  margin-top: 30px;\n  margin-left: 30px;\n}"
+          Replace: "#dictionary[qApp_deviceIsDragon=true] {\n  margin-top: 10px;\n  margin-left: 0px;\n}"
+          # AuraOne/Forma/Sage/Elipsa/Elipsa2E
+        - Find:    "#dictionary[qApp_deviceIsDaylight=true] {\n  margin-top: 42px;\n  margin-left: 42px;\n}"
+          Replace: "#dictionary[qApp_deviceIsDaylight=true] {\n  margin-top: 14px;\n  margin-left: 0px;\n}"
+        #
+        # Part 1b: #header - reduce header height
+          # Touch/Mini
+        - Find:    "#header[qApp_deviceIsTrilogy=true] {\n  max-height: 46px;\n  min-height: 46px;\n}"
+          Replace: "#header[qApp_deviceIsTrilogy=true] {\n  max-height: 46px;\n  min-height: 46px;\n}"
+          # Glo/Aura/Aura2/Nia
+        - Find:    "#header[qApp_deviceIsPhoenix=true] {\n  max-height: 60px;\n  min-height: 60px;\n}"
+          Replace: "#header[qApp_deviceIsPhoenix=true] {\n  max-height: 50px;\n  min-height: 50px;\n}"
+          # AuraHD/AuraH2O/AuraH2O2/GloHD/ClaraHD/Clara2E/LibraH2O/Libra2
+        - Find:    "#header[qApp_deviceIsDragon=true] {\n  max-height: 90px;\n  min-height: 90px;\n}"
+          Replace: "#header[qApp_deviceIsDragon=true] {\n  max-height: 70px;\n  min-height: 70px;\n}"
+          # AuraOne/Forma/Sage/Elipsa/Elipsa2E
+        - Find:    "#header[qApp_deviceIsDaylight=true] {\n  max-height: 120px;\n  min-height: 120px;\n}"
+          Replace: "#header[qApp_deviceIsDaylight=true] {\n  max-height: 90px;\n  min-height: 90px;\n}"
+        #
+        # Part 1c: #mainContainer - reduce left/right margins
+          # Touch/Mini
+        - Find:    "#mainContainer[qApp_deviceIsTrilogy=true] {\n  qproperty-leftMargin: 12px;\n  qproperty-rightMargin: 12px;\n}"
+          Replace: "#mainContainer[qApp_deviceIsTrilogy=true] {\n  qproperty-leftMargin: 6px;\n  qproperty-rightMargin: 6px;\n}"
+          # Glo/Aura/Aura2/Nia
+        - Find:    "#mainContainer[qApp_deviceIsPhoenix=true] {\n  qproperty-leftMargin: 16px;\n  qproperty-rightMargin: 16px;\n}"
+          Replace: "#mainContainer[qApp_deviceIsPhoenix=true] {\n  qproperty-leftMargin: 8px;\n  qproperty-rightMargin: 8px;\n}"
+          # AuraHD/AuraH2O/AuraH2O2/GloHD/ClaraHD/Clara2E
+        - Find:    "#mainContainer[qApp_deviceIsDragon=true] {\n  qproperty-leftMargin: 22px;\n  qproperty-rightMargin: 22px;\n}"
+          Replace: "#mainContainer[qApp_deviceIsDragon=true] {\n  qproperty-leftMargin: 11px;\n  qproperty-rightMargin: 11px;\n}"
+          # AuraOne/Forma/Sage/Elipsa/Elipsa2E
+        - Find:    "#mainContainer[qApp_deviceIsDaylight=true] {\n  qproperty-leftMargin: 28px;\n  qproperty-rightMargin: 28px;\n}"
+          Replace: "#mainContainer[qApp_deviceIsDaylight=true] {\n  qproperty-leftMargin: 14px;\n  qproperty-rightMargin: 14px;\n}"
+          # LibraH2O/Libra2
+        - Find:    "#mainContainer[qApp_deviceIsStorm=true] {\n  qproperty-leftMargin: 25px;\n  qproperty-rightMargin: 25px;\n}"
+          Replace: "#mainContainer[qApp_deviceIsStorm=true] {\n  qproperty-leftMargin: 12px;\n  qproperty-rightMargin: 12px;\n}"
+  #
+  # Part 2: DictionaryViewFooter - Reduce vertical height of footer # qss/DictionaryViewFooter.qss
+    # Touch/Mini
+  - FindReplaceString:
+      Find:    "DictionaryViewFooter[qApp_deviceIsTrilogy=true] {\n  max-height: 46px;\n  min-height: 46px;\n}"
+      Replace: "DictionaryViewFooter[qApp_deviceIsTrilogy=true] {\n  max-height: 40px;\n  min-height: 40px;\n}"
+      MustMatchLength: yes
+    # Glo/Aura/Aura2/Nia
+  - FindReplaceString:
+      Find:    "DictionaryViewFooter[qApp_deviceIsPhoenix=true] {\n  max-height: 60px;\n  min-height: 60px;\n}"
+      Replace: "DictionaryViewFooter[qApp_deviceIsPhoenix=true] {\n  max-height: 50px;\n  min-height: 50px;\n}"
+      MustMatchLength: yes
+    # AuraHD/AuraH2O/AuraH2O2/GloHD/ClaraHD/Clara2E/LibraH2O/Libra2
+  - FindReplaceString:
+      Find:    "DictionaryViewFooter[qApp_deviceIsDragon=true] {\n  max-height: 90px;\n  min-height: 90px;\n}"
+      Replace: "DictionaryViewFooter[qApp_deviceIsDragon=true] {\n  max-height: 60px;\n  min-height: 60px;\n}"
+      MustMatchLength: yes
+    # AuraOne/Forma/Sage/Elipsa/Elipsa2E
+  - FindReplaceString:
+      Find:    "DictionaryViewFooter[qApp_deviceIsDaylight=true] {\n  max-height: 120px;\n  min-height: 120px;\n}"
+      Replace: "DictionaryViewFooter[qApp_deviceIsDaylight=true] {\n  max-height:  80px;\n  min-height:  80px;\n}"
+      MustMatchLength: yes
+
+Increase Book Details synopsis area:
+  - Enabled: no
+  - Description: |
+      Book details page
+      - Increase height of bottom half (Synopsis) by
+        decreasing height of top half (Cover, Title, Author, Series)
+      - See https://www.mobileread.com/forums/showpost.php?p=3311354&postcount=134
+      - fw 4.12/4.16 - rewritten by jackie_w to replace oren64's patch
+  - FindZlib: "#bookInfoWidget" # qss/BookInfoView.qss
+  - ReplaceZlibGroup:
+      Replacements:
+        #   Portrait mode:  #bookInfoWidget[isLandscape=false]:
+        - {Find: "height: 300px;", Replace: "height: 200px;"} #Touch/Mini
+        - {Find: "height: 390px;", Replace: "height: 230px;"} #Glo/Aura/Aura2/Nia
+        - {Find: "height: 550px;", Replace: "height: 370px;"} #AuraHD/AuraH2O/AuraH202/GloHD/ClaraHD/Clara2E
+        - {Find: "height: 642px;", Replace: "height: 425px;"} #LibraH2O/Libra2
+        - {Find: "height: 715px;", Replace: "height: 500px;"} #AuraOne/Forma/Sage/Elipsa/Elipsa2E
+        #   Landscape mode:  #bookInfoWidget[isLandscape=true]:
+        - {Find: "height: 210px;", Replace: "height: 200px;"} #Touch/Mini
+        - {Find: "height: 265px;", Replace: "height: 230px;"} #Glo/Aura/Aura2/Nia
+        - {Find: "height: 420px;", Replace: "height: 370px;"} #AuraHD/AuraH2O/AuraH202/GloHD/ClaraHD/Clara2E
+        - {Find: "height: 490px;", Replace: "height: 425px;"} #LibraH2O/Libra2
+        - {Find: "height: 540px;", Replace: "height: 500px;"} #AuraOne/Forma/Sage/Elipsa/Elipsa2E
+
+Increase library cover size:
+  - Enabled: no
+  - Description: |
+      Increase the cover thumbnail size in My Books main book list
+      See screenshots - https://www.mobileread.com/forums/showpost.php?p=3241532&postcount=82
+      fw 4.17 - rewritten by jackie_w to replace oren64's patch
+      fw 4.24 - updated patch "width" values to maintain aspect ratio of original value
+  - FindZlib: "#coverPixmapView" # qss/DragonListWidget.qss
+  - ReplaceZlibGroup:
+      Replacements:
+        # coverPixmapView increase cover thumbnail width/height:
+        # Touch/Mini (Trilogy)
+        - {Find: "width: 60px;",   Replace: "width: 66px;"}
+        - {Find: "height: 90px;",  Replace: "height: 100px;"}
+        # Glo/Aura/Aura2/Nia (Phoenix)
+        - {Find: "width: 70px;",   Replace: "width: 82px;"}
+        - {Find: "height: 110px;", Replace: "height: 130px;"}
+        # AuraHD/AuraH2O/AuraH202/GloHD/ClaraHD/Clara2E (Dragon)
+        - {Find: "width: 108px;",  Replace: "width: 122px;"}
+        - {Find: "height: 168px;", Replace: "height: 190px;"}
+        # AuraOne/Forma/Sage/Elipsa/Elipsa2E (Daylight)
+        - {Find: "width: 140px;",  Replace: "width: 164px;"}
+        - {Find: "height: 218px;", Replace: "height: 255px;"}
+        # LibraH2O/Libra2 (Storm)
+        - {Find: "width: 126px;",  Replace: "width: 144px;"}
+        - {Find: "height: 196px;", Replace: "height: 225px;"}
+
+Custom collection/author header title font:
+  - Enabled: no
+  - Description: |
+      Change font appearance in Collection and Author list header
+      See https://www.mobileread.com/forums/showpost.php?p=3520879&postcount=42
+      fw 4.17.13694 rewritten by jackie_w to replace 
+      oren64's patch "Custom font to collection and author titles"
+      fw 4.23.15505: Author/Series/Collection list headers no longer forced to uppercase
+      fw 4.32.19501: Kobo's major changes to font handling mean that ability to customise
+         font-family in a kobopatch is now very limited.
+      fw 4.39.xxxxx: GUI serif/sans-serif system fonts now referred to generically as
+            DefaultSerif/DefaultSansSerif respectively.
+  - FindZlib: "#scrollContainer[containerSpacing=true]" # qss/DragonLibraryView.qss
+  - ReplaceZlibGroup:
+      Replacements:
+        # #header #headerTitle Change font-family, font-size
+        #
+        # Change font-family. The only custom font-family values now likely to have any effect
+        #   are DefaultSerif, DefaultSansSerif and possibly(?) some of the built-in CJK fonts
+        # Un-comment & edit next line to change font-family
+        #- {Find: "font-family: DefaultSansSerif;", Replace: "font-family:DefaultSerif;"}
+        #
+        # Increase font-size.
+          # Touch/Mini (Trilogy)
+        - {Find: "font-size: 16px;", Replace: "font-size: 28px;"}
+          # Glo/Aura/Aura2/Nia (Phoenix)
+        - {Find: "font-size: 20px;", Replace: "font-size: 36px;"}
+          # AuraHD/AuraH2O/AuraH202/GloHD & all Clara* (Dragon)
+        - {Find: "font-size: 28px;", Replace: "font-size: 42px;"}
+          # all Libra* (Storm)
+        - {Find: "font-size: 32px;", Replace: "font-size: 46px;"}
+          # AuraOne/Forma/Sage & all Elipsa* (Daylight)
+        - {Find: "font-size: 36px;", Replace: "font-size: 50px;"}
+
+Reduce new header/footer height:
+  - Enabled: no
+  - Description: |
+        Reduce new reading header/footer heights when they are enabled.
+        Affects both ePubs and KePubs.
+        This patch may be of interest to those who used to enable the old
+        "Custom menubar - reduce height by 33%"
+  - FindZlib: "ReadingFooter" # qss/ReadingFooter.qss
+  - ReplaceZlibGroup:
+      # Adjust the Replace values of min-height/max-height as you wish.
+      # Keep min-height=max-height
+      Replacements:
+        # ReadingFooter Reduce min/max height by 33%
+        # Touch/Mini (Trilogy)
+      - Find:    "ReadingFooter[qApp_deviceIsTrilogy=true] {\n  min-height: 56;\n  max-height: 56px;\n}"
+        Replace: "ReadingFooter[qApp_deviceIsTrilogy=true] {\n  min-height: 37px;\n  max-height: 37px;\n}"
+        # Glo/Aura/Aura2/Nia (Phoenix)
+      - Find:    "ReadingFooter[qApp_deviceIsPhoenix=true] {\n  min-height: 71px;\n  max-height: 71px;\n}"
+        Replace: "ReadingFooter[qApp_deviceIsPhoenix=true] {\n  min-height: 47px;\n  max-height: 47px;\n}"
+        # AuraHD/AuraH2O/AuraH202/GloHD/ClaraHD/Clara2E (Dragon)
+      - Find:    "ReadingFooter[qApp_deviceIsDragon=true] {\n  min-height: 101px;\n  max-height: 101px;\n}"
+        Replace: "ReadingFooter[qApp_deviceIsDragon=true] {\n  min-height: 66px;\n  max-height: 66px;\n}"
+        # AuraOne/Forma/Sage/Elipsa/Elipsa2E (Daylight)
+      - Find:    "ReadingFooter[qApp_deviceIsDaylight=true] {\n  min-height: 131px;\n  max-height: 131px;\n}"
+        Replace: "ReadingFooter[qApp_deviceIsDaylight=true] {\n  min-height: 86px;\n  max-height: 86px;\n}"
+        # LibraH2O/Libra2 (Storm)
+      - Find:    "ReadingFooter[qApp_deviceIsStorm=true] {\n  min-height: 118px;\n  max-height: 118px;\n}"
+        Replace: "ReadingFooter[qApp_deviceIsStorm=true] {\n  min-height: 78px;\n  max-height: 78px;\n}"
+
+Custom header/footer captions:
+  - Enabled: no
+  - Description: |
+        This patch allows you to change various header/footer caption attributes:
+        - font-family (Part 1)
+        - font-size & vertical position fine-tuning (Part 2)
+        - width (Part 3)
+        Header & footer will automatically be a matched pair. 
+        Parts 1 & 2: Full details & screenshots at 
+        https://www.mobileread.com/forums/showpost.php?p=3897175&postcount=4
+        Part 3: Before/after screenshots at
+        https://www.mobileread.com/forums/showpost.php?p=4069495&postcount=18
+        #
+        N.B: This patch is not suitable for Japanese/Chinese locale users
+        fw 4.23.15505: No longer possible to customise font-size for GloHD/ClaraHD
+            separately from AuraHD/H2O.
+        fw 4.29.18730: No longer possible to style header/footer separately.
+        fw 4.32.19501: Kobo's major changes to font handling mean that ability to customise
+            font-family in a kobopatch is now very limited.
+        fw 4.39.xxxxx: GUI serif/sans-serif system fonts now referred to generically as
+            DefaultSerif/DefaultSansSerif respectively.
+
+  - FindZlib: "ReadingFooter" # qss/ReadingFooter.qss
+  - ReplaceZlibGroup:
+      Replacements:
+        # Part 1: Customise font-family
+        # #caption
+        # The only custom font-family values now likely to have any effect 
+        #   are DefaultSerif, DefaultSansSerif and possibly(?) some of the built-in CJK fonts
+        # Un-comment and customise ONLY ONE of the following to change header/footer font-family
+        #- {Find: "font-family: DefaultSansSerif;", Replace: "font-family:DefaultSansSerif;"}
+        #- {Find: "font-family: DefaultSansSerif;", Replace: "font-family:DefaultSansSerif; background:transparent;"}
+
+        # Hint: 
+        #   Even if you don't need to change font-family you might want to un-comment the 2nd Find/Replace above.
+        #   Setting the caption's background to transparent instead of the default, opaque white,
+        #   should avoid the potential "dogear bookmark problem" outlined below in Part 3 of this patch. 
+
+        # Part 2:
+        #   2a. Change font-size (header & footer simultaneously)
+        #       Separate values for GloHD & ClaraHD (Alyssum & Nova) removed in 4.23.15505
+        #
+        #   2b.(optional): Fine-tune footer position by adjusting value of margin-top.
+        #                  A negative margin-top (e.g. -10px) moves the footer text 
+        #                  slightly upwards, further away from the bottom bezel/progressbar,
+        #                  closer to the page content.
+        #                  N.B. A non-zero margin-top also automatically shifts the header text
+        #                       vertically by the same amount and in the same direction
+        #                       as the footer text.
+        # #caption
+          # Touch/Mini
+        - Find:    "[qApp_deviceIsTrilogy=true] {\n  font-size: 14px;\n}"
+          Replace: "[qApp_deviceIsTrilogy=true] {\n  font-size: 14px; margin-top: 0px;\n}"
+          # Glo/Aura/Aura2/Nia
+        - Find:    "[qApp_deviceIsPhoenix=true] {\n  font-size: 17px;\n}"
+          Replace: "[qApp_deviceIsPhoenix=true] {\n  font-size: 17px; margin-top: 0px;\n}"
+          # AuraHD/AuraH2O/AuraH202/GloHD & all Clara*
+        - Find:    "[qApp_deviceIsDragon=true] {\n  font-size: 25px;\n}"
+          Replace: "[qApp_deviceIsDragon=true] {\n  font-size: 25px; margin-top: 0px;\n}"
+          # all Libra*
+        - Find:    "[qApp_deviceIsStorm=true] {\n  font-size: 29px;\n}"
+          Replace: "[qApp_deviceIsStorm=true] {\n  font-size: 29px; margin-top: 0px;\n}"
+          # AuraOne/Forma/Sage & all Elipsa*
+        - Find:    "[qApp_deviceIsDaylight=true] {\n  font-size: 32px;\n}"
+          Replace: "[qApp_deviceIsDaylight=true] {\n  font-size: 32px; margin-top: 0px;\n}"
+
+        # Part 3: Increase the width of header/footer captions by reducing the width
+        #         of the pageturn tap zones in the footer's left/right corners
+        # N.B: 
+        #   The default Replace values below have been set larger than you might prefer.
+        #     This is to avoid the possibility of the "dogear" bookmark icon
+        #     in the top right corner being partially obscured by the header caption's white background.
+        #   See screenshot at following link for an example of what can happen 
+        #     if the new Replace value is too small.
+        #     https://www.mobileread.com/forums/showpost.php?p=4069755&postcount=34
+        #   Feel free to reduce your custom Replace values if a wider caption area
+        #     is more important to you than "dogear" aesthetics. 
+        #     Alternatively, look at the Hint in Part 1 of this patch for a way to avoid
+        #     the "dogear" problem.
+        #
+        # Customise one or more of the 3 Replace values below as required
+          # Touch/Mini/Touch2/Glo/Aura/Aura2/Nia
+          # N.B. Touch/Mini/Touch2 could be reduced to 57 with no ill effects
+        - {Find: "footerMargin: 105;", Replace: "footerMargin:64;"}
+        
+          # AuraHD/AuraH2O/AuraH2O2/GloHD/ClaraHD/Clara2E/LibraH2O/Libra2
+          # N.B. AuraH2O/AuraH2O2/GloHD/ClaraHD/Clara2E could be reduced to 102 with no ill effects
+        - {Find: "footerMargin: 170;", Replace: "footerMargin:116;"}
+        
+          # AuraOne/Forma/Sage/Elipsa/Elipsa2E
+        - {Find: "footerMargin: 221;", Replace: "footerMargin:133;"}
+
+        # Don't change anything below. It exists to free up some space for
+        # your changes above by removing Japanese/Chinese-specific CSS code blocks
+        # so that kobopatch will run without giving some kind of 'too long' error message.
+        - {Find: "#caption[localeName=\"ja\"] {\n  font-family: Sans-SerifJP, sans-serif;\n  font-style: normal;\n}\n", Replace: "\n"}
+        - {Find: "#caption[localeName=\"zh\"] {\n  font-family: Sans-SerifZH-Simplified, sans-serif;\n  font-style: normal;\n}\n", Replace: "\n"}
+        - {Find: "#caption[localeName=\"zh-HK\"] {\n  font-family: Sans-SerifZH-Traditional, sans-serif;\n  font-style: normal;\n}\n", Replace: "\n"}
+        - {Find: "#caption[localeName=\"zh-TW\"] {\n  font-family: Sans-SerifZH-Traditional, sans-serif;\n  font-style: normal;\n}\n", Replace: "\n"}
+
+Custom page navigation scrubber:
+  - Enabled: no
+  - Description: |
+        This patch allows you to customise various parts of the new 'scrubber'. Full details & screenshots at:
+        https://www.mobileread.com/forums/showpost.php?p=3897174&postcount=3
+        N.B: This patch is not suitable for Japanese/Chinese locale users
+        fw 4.32.19501: Kobo's major changes to font handling mean that ability to customise
+            font-family in a kobopatch is now very limited.
+        fw 4.39.xxxxx: GUI serif/sans-serif system fonts now referred to generically as
+            DefaultSerif/DefaultSansSerif respectively.
+  - FindZlib: "#scrubberContainer" # qss/ReadingMenuScrubberView.qss
+  - ReplaceZlibGroup:
+      Replacements:
+        # Part 1. Customise all 3 of these buttons
+        #    - Left & Right 'Back to page nnn' (#revertLeft, #revertRight)
+        #    - Current chapter name (#chapter)
+
+        # 1a. Customise font-size for desired model(s):
+          # Touch/Mini (Trilogy)
+        - Find:    "[qApp_deviceIsTrilogy=true] {\n  font-size: 19px;"
+          Replace: "[qApp_deviceIsTrilogy=true] {\n  font-size: 19px;"
+          # Glo/Aura/Aura2/Nia (Phoenix)
+        - Find:    "[qApp_deviceIsPhoenix=true] {\n  font-size: 23px;"
+          Replace: "[qApp_deviceIsPhoenix=true] {\n  font-size: 23px;"
+          # AuraHD/AuraH2O/AuraH202 (Dragon)
+        - Find:    "[qApp_deviceIsDragon=true] {\n  font-size: 29px;"
+          Replace: "[qApp_deviceIsDragon=true] {\n  font-size: 29px;"
+          # GloHD (Alyssum)
+        - Find:    "[qApp_deviceIsAlyssum=true] {\n  font-size: 32px;"
+          Replace: "[qApp_deviceIsAlyssum=true] {\n  font-size: 32px;"
+          # all Clara* (Nova)
+        - Find:    "[qApp_deviceIsNova=true] {\n  font-size: 32px;"
+          Replace: "[qApp_deviceIsNova=true] {\n  font-size: 32px;"
+          # all Libra* (Storm)
+        - Find:    "[qApp_deviceIsStorm=true] {\n  font-size: 34px;"
+          Replace: "[qApp_deviceIsStorm=true] {\n  font-size: 34px;"
+          # AuraOne/Forma/Sage & all Elipsa* (Daylight)
+        - Find:    "[qApp_deviceIsDaylight=true] {\n  font-size: 37px;"
+          Replace: "[qApp_deviceIsDaylight=true] {\n  font-size: 37px;"
+
+        # 1b. Customise other font properties of these 3 buttons (all models):
+        #     - font-family. The only custom font-family values now likely to have any effect are
+        #           DefaultSerif, DefaultSansSerif and possibly(?) some of the built-in CJK fonts
+        #     - font-weight (bold or normal)
+        #     - font-style  (italic or normal)
+        - Find:    "{\n  font-family: DefaultSansSerif;\n  font-weight: bold;\n  font-style: normal;\n}"
+          Replace: "{font-family:DefaultSansSerif; font-weight:bold; font-style:normal;}"
+        # Users with CSS knowledge can add extra style properties as desired,
+        # e.g. to make them look more like buttons and less like labels,
+        #      use this Replace instead. If it can be done with CSS you can do it here.
+          #Replace: "{font-family:DefaultSansSerif; font-weight:normal; font-style:normal; background:#ddd;}"
+
+        # Part 2. Customise the central 'Page x of y' label (#page)
+        #         Provided for those who want to create a uniform look & feel
+        # 2a. Customise font-size for desired model(s):
+          # Touch/Mini (Trilogy)
+        - Find:    "#page[qApp_deviceIsTrilogy=true] {\n  font-size: 17px;"
+          Replace: "#page[qApp_deviceIsTrilogy=true] {\n  font-size: 17px;"
+          # Glo/Aura/Aura2/Nia (Phoenix)
+        - Find:    "#page[qApp_deviceIsPhoenix=true] {\n  font-size: 22px;"
+          Replace: "#page[qApp_deviceIsPhoenix=true] {\n  font-size: 22px;"
+          # AuraHD/AuraH2O/AuraH202 (Dragon)
+        - Find:    "#page[qApp_deviceIsDragon=true] {\n  font-size: 26px;"
+          Replace: "#page[qApp_deviceIsDragon=true] {\n  font-size: 26px;"
+          # GloHD (Alyssum)
+        - Find:    "#page[qApp_deviceIsAlyssum=true] {\n  font-size: 30px;"
+          Replace: "#page[qApp_deviceIsAlyssum=true] {\n  font-size: 30px;"
+          # all Clara* (Nova)
+        - Find:    "#page[qApp_deviceIsNova=true] {\n  font-size: 30px;"
+          Replace: "#page[qApp_deviceIsNova=true] {\n  font-size: 30px;"
+          # all Libra* (Storm)
+        - Find:    "#page[qApp_deviceIsStorm=true] {\n  font-size: 30px;"
+          Replace: "#page[qApp_deviceIsStorm=true] {\n  font-size: 30px;"
+          # AuraOne/Forma/Sage & all Elipsa* (Daylight)
+        - Find:    "#page[qApp_deviceIsDaylight=true] {\n  font-size: 34px;"
+          Replace: "#page[qApp_deviceIsDaylight=true] {\n  font-size: 34px;"
+
+        # 2b. Customise other font properties of 'Page x of y' label (all models)
+        #     e.g. text-transform (uppercase or none)
+        #          font-family, font-weight, font-style, etc.
+        # Un-comment next 2 lines and change Replace CSS as desired
+        #- Find:    "#page {\n  padding-left: 0px;\n}"
+        #  Replace: "#page {padding-left:0; font-family:DefaultSerif; text-transform:none;}"
+
+Customise Header back button:
+  - Enabled: no
+  - Description: |
+        Customise in-book button (top left corner) for 'Back to Home', 'Back to My Books' etc
+        fw 4.32.19501: Kobo's major changes to font handling mean that ability to customise
+            font-family in a kobopatch is now very limited.
+        fw 4.39.xxxxx: GUI serif/sans-serif system fonts now referred to generically as
+            DefaultSerif/DefaultSansSerif respectively.
+  - FindZlib: "#ReadingMenuView" # qss/ReadingMenuView.qss
+  - ReplaceZlibGroup:
+      Replacements:
+        # 'Back to Home' button un-bolded
+        - Find:    "#backLabel #label {\n  font-family: DefaultSansSerif;\n  font-style: normal;\n  font-weight: bold;"
+          Replace: "#backLabel #label {\n  font-family:DefaultSansSerif;\n  font-style:normal;\n  font-weight:normal;"
+
+Series list increase cover thumbnails:
+  - Enabled: no
+  - Description: |
+      Series list view (not Series cover view). Increase cover thumbnail size.
+      fw 4.24 - updated patch "width" values to maintain aspect ratio of original value
+  - FindZlib: "#seriesCoverPack" # qss/SeriesListWidget.qss
+  - ReplaceZlibGroup:
+      Replacements:
+        # Part 1: #seriesWidgetContainer - Reduce top/bottom margins
+        #   NB: The smaller the topMargin the closer the Series name
+        #       will be to the horizontal gridline above it
+          # Touch/Mini
+        - {Find: "topMargin: 9px;",     Replace: "topMargin: 3px;"}
+        - {Find: "bottomMargin: 9px;",  Replace: "bottomMargin: 0px;"}
+          # Glo/Aura/Aura2/Nia
+        - {Find: "topMargin: 12px;",    Replace: "topMargin: 4px;"}
+        - {Find: "bottomMargin: 12px;", Replace: "bottomMargin: 0px;"}
+          # AuraHD/AuraH2O/AuraH202/GloHD/ClaraHD/Clara2E
+        - {Find: "topMargin: 14px;",    Replace: "topMargin: 5px;"}
+        - {Find: "bottomMargin: 14px;", Replace: "bottomMargin: 0px;"}
+          # AuraOne/Forma/Sage/Elipsa/Elipsa2E
+        - {Find: "topMargin: 21px;",    Replace: "topMargin: 7px;"}
+        - {Find: "bottomMargin: 21px;", Replace: "bottomMargin: 0px;"}
+          # LibraH2O/Libra2
+        - {Find: "topMargin: 17px;",    Replace: "topMargin: 6px;"}
+        - {Find: "bottomMargin: 17px;", Replace: "bottomMargin: 0px;"}
+        #
+        # Part 2: #seriesCoverPack - Increase cover thumbnail size
+          # Touch/Mini
+        - {Find: "width: 60px;",   Replace: "width: 65px;"}
+        - {Find: "height: 94px;",  Replace: "height: 102px;"}
+          # Glo/Aura/Aura2/Nia
+        - {Find: "width: 70px;",   Replace: "width: 83px;"}
+        - {Find: "height: 115px;", Replace: "height: 137px;"}
+          # AuraHD/AuraH2O/AuraH202/GloHD/ClaraHD/Clara2E
+        - {Find: "width: 108px;",  Replace: "width: 120px;"}
+        - {Find: "height: 175px;", Replace: "height: 195px;"}
+          # AuraOne/Forma/Sage/Elipsa/Elipsa2E
+        - {Find: "width: 140px;",  Replace: "width: 164px;"}
+        - {Find: "height: 222px;", Replace: "height: 260px;"}
+          # LibraH2O/Libra2
+        - {Find: "width: 126px;",  Replace: "width: 141px;"}
+        - {Find: "height: 205px;", Replace: "height: 229px;"}
+        #
+        # Part 3: All models: #hBooks - Move bookcount up & away from horizontal gridline
+        #         Users of lower-res models (Touch/Mini/Glo/Aura6"/Aurav2) may prefer to
+        #         decrease the Replace value of 20px for padding-bottom
+        - Find:    "#hBooks {\n  padding-left: 0px;\n  padding-bottom: 0px;\n  font-style: normal;\n}"
+          Replace: "#hBooks {\n  padding-left: 0px;\n  padding-bottom:20px;\n  font-style: normal;\n}"

--- a/src/versions/4.40.23081/nickel.yaml/oren64.yaml
+++ b/src/versions/4.40.23081/nickel.yaml/oren64.yaml
@@ -1,0 +1,117 @@
+# The following patch(es) are ported from oren64's patches
+
+Increase headlines font:
+  - Enabled: no
+  - Description: |
+      Increase the font-size of the tab header labels in My Books, Activity, Bookstore...
+      See https://www.mobileread.com/forums/showpost.php?p=3931942&postcount=183
+  - FindZlib: "#tabContainer > N3TabItem" # qss/N3TabWidget.qss
+  - ReplaceZlibGroup:
+      Replacements:
+          # Touch/Mini
+        - Find:    "#tabContainer > N3TabItem[qApp_deviceIsTrilogy=true] {\n  font-size: 16px;\n}"
+          Replace: "#tabContainer > N3TabItem[qApp_deviceIsTrilogy=true] {\n  font-size: 28px;\n}"
+          # Glo/Aura/Aura2E/Nia
+        - Find:    "#tabContainer > N3TabItem[qApp_deviceIsPhoenix=true] {\n  font-size: 20px;\n}"
+          Replace: "#tabContainer > N3TabItem[qApp_deviceIsPhoenix=true] {\n  font-size: 36px;\n}"
+          # AuraHD/AuraH2O/AuraH2O2/GloHD/ClaraHD/Clara2E
+        - Find:    "#tabContainer > N3TabItem[qApp_deviceIsDragon=true] {\n  font-size: 28px;\n}"
+          Replace: "#tabContainer > N3TabItem[qApp_deviceIsDragon=true] {\n  font-size: 42px;\n}"
+          # LibraH2O/Libra2
+        - Find:    "#tabContainer > N3TabItem[qApp_deviceIsStorm=true] {\n  font-size: 32px;\n}"
+          Replace: "#tabContainer > N3TabItem[qApp_deviceIsStorm=true] {\n  font-size: 46px;\n}"
+          # AuraONE/Forma/Sage/Elipsa/Elipsa2E
+        - Find:    "#tabContainer > N3TabItem[qApp_deviceIsDaylight=true] {\n  font-size: 36px;\n}"
+          Replace: "#tabContainer > N3TabItem[qApp_deviceIsDaylight=true] {\n  font-size: 50px;\n}"
+
+New home screen subtitle custom font:
+  - Enabled: no
+  - Description: |
+      On the Home screen:
+        Change upper label font-size
+        Change subtitle (lower label) font size and/or font colour.
+      Upper label example is the black text caption
+      - 'x% Read' - top row
+      - 'My Books' - middle row
+      Subtitle (lower label) examples are the grey text captions containing:
+      - 'x HOURS TO GO' for kepubs (not shown for epubs) - top row
+      - 'x BOOKS' under 'My Books' - middle row
+      Works best when used with with patch `Increase home screen cover size`
+  - FindZlib: "#homeWidgetTopContainer" # qss/GenericHomeWidget.qss
+  - ReplaceZlibGroup:
+      Replacements:
+        # Change subtitle (lower label) font colour from mid-grey to black
+        - {Find: "MetaDataLabel {\n  color: #666666;\n  qproperty-indent: 0;\n}", Replace: "MetaDataLabel {\n  color: #000000;\n  qproperty-indent: 0;\n}"}
+        #
+        # Change subtitle (lower label) font-size (e.g. time remaining in book)
+          # Touch/Mini (Trilogy)
+        - Find:    "MetaDataLabel[qApp_deviceIsTrilogy=true] {\n  font-size: 13px;\n}"
+          Replace: "MetaDataLabel[qApp_deviceIsTrilogy=true] {\n  font-size: 14px;\n}"
+          # Glo/Aura/Aura2E/Nia (Phoenix)
+        - Find:    "MetaDataLabel[qApp_deviceIsPhoenix=true] {\n  font-size: 17px;\n}"
+          Replace: "MetaDataLabel[qApp_deviceIsPhoenix=true] {\n  font-size: 18px;\n}"
+          # AuraHD/AuraH2O/AuraH2O2/GloHD/ClaraHD/Clara2E (Dragon)
+        - Find:    "MetaDataLabel[qApp_deviceIsDragon=true] {\n  font-size: 24px;\n}"
+          Replace: "MetaDataLabel[qApp_deviceIsDragon=true] {\n  font-size: 26px;\n}"
+          # LibraH2O/Libra2 (Storm)
+        - Find:    "MetaDataLabel[qApp_deviceIsStorm=true] {\n  font-size: 28px;\n}"
+          Replace: "MetaDataLabel[qApp_deviceIsStorm=true] {\n  font-size: 30px;\n}"
+          # AuraONE/Forma/Sage/Elipsa/Elipsa2E (Daylight)
+        - Find:    "MetaDataLabel[qApp_deviceIsDaylight=true] {\n  font-size: 31px;\n}"
+          Replace: "MetaDataLabel[qApp_deviceIsDaylight=true] {\n  font-size: 34px;\n}"
+        #
+        # Change upper label (black) font-size (e.g. % Read)
+          # Touch/Mini (Trilogy)
+        - Find:    "RegularElidedLabel[qApp_deviceIsTrilogy=true] {\n  font-size: 21px;\n}"
+          Replace: "RegularElidedLabel[qApp_deviceIsTrilogy=true] {\n  font-size: 21px;\n}"
+          # Glo/Aura/Aura2E/Nia (Phoenix)
+        - Find:    "RegularElidedLabel[qApp_deviceIsPhoenix=true] {\n  font-size: 26px;\n}"
+          Replace: "RegularElidedLabel[qApp_deviceIsPhoenix=true] {\n  font-size: 26px;\n}"
+          # AuraHD/AuraH2O/AuraH2O2/GloHD/ClaraHD/Clara2E (Dragon)
+        - Find:    "RegularElidedLabel[qApp_deviceIsDragon=true] {\n  font-size: 36px;\n}"
+          Replace: "RegularElidedLabel[qApp_deviceIsDragon=true] {\n  font-size: 36px;\n}"
+          # LibraH2O/Libra2 (Storm)
+        - Find:    "RegularElidedLabel[qApp_deviceIsStorm=true] {\n  font-size: 42px;\n}"
+          Replace: "RegularElidedLabel[qApp_deviceIsStorm=true] {\n  font-size: 42px;\n}"
+          # AuraONE/Forma/Sage/Elipsa/Elipsa2E (Daylight)
+        - Find:    "RegularElidedLabel[qApp_deviceIsDaylight=true] {\n  font-size: 47px;\n}"
+          Replace: "RegularElidedLabel[qApp_deviceIsDaylight=true] {\n  font-size: 47px;\n}"
+
+Remove footer (row3) and increase cover size on new home screen:
+  - Enabled: no
+  - PatchGroup: Home screen layout tweaks
+  - Description: |
+      Combines two patches together which share the same PatchGroup:
+      - `Increase home screen cover size`
+      - `Remove footer (row3) on new home screen`
+  - FindZlib: "#row1col2" # qss/HomePageView.qss
+  - ReplaceZlibGroup:
+      Replacements:
+        # patch `Increase home screen cover size`
+        # Touch/Mini (Trilogy)
+      - {Find: "qproperty-leftMargin: 32px;",  Replace: "qproperty-leftMargin: 16px;"}
+      - {Find: "qproperty-rightMargin: 32px;", Replace: "qproperty-rightMargin: 16px;"}
+        # Glo/Aura/Aura2E/Nia (Phoenix)
+      - {Find: "qproperty-leftMargin: 40px;",  Replace: "qproperty-leftMargin: 16px;"}
+      - {Find: "qproperty-rightMargin: 40px;", Replace: "qproperty-rightMargin: 16px;"}
+        # AuraHD/AuraH2O/AuraH2O2/GloHD/ClaraHD/Clara2E (Dragon)
+      - {Find: "qproperty-leftMargin: 57px;",  Replace: "qproperty-leftMargin: 22px;"}
+      - {Find: "qproperty-rightMargin: 57px;", Replace: "qproperty-rightMargin: 22px;"}
+        # AuraONE/Forma/Sage/Elipsa/Elipsa2E (Daylight)
+      - {Find: "qproperty-leftMargin: 74px;",  Replace: "qproperty-leftMargin: 29px;"}
+      - {Find: "qproperty-rightMargin: 74px;", Replace: "qproperty-rightMargin: 29px;"}
+        # LibraH2O/Libra2 (Storm)
+      - {Find: "qproperty-leftMargin: 67px;",  Replace: "qproperty-leftMargin: 29px;"}
+      - {Find: "qproperty-rightMargin: 67px;", Replace: "qproperty-rightMargin: 29px;"}
+        #
+        # patch `Remove footer (row3) on new home screen`
+      - Find:    "#row1col2 {\n  qproperty-visible: false;\n}"
+        Replace: "#row1col2 {\n  qproperty-visible: false;\n}\n#row3 {\n  qproperty-visible: false;\n}"
+
+Remove footer (row3) on new home screen:
+  - Enabled: no
+  - PatchGroup: Home screen layout tweaks
+  - FindZlib: "#row1col2" # qss/HomePageView.qss
+  - ReplaceZlib:
+      Find:    "#row1col2 {\n  qproperty-visible: false;\n}"
+      Replace: "#row1col2 {\n  qproperty-visible: false;\n}\n#row3 {\n  qproperty-visible: false;\n}"

--- a/src/versions/4.40.23081/nickel.yaml/pgaskin.yaml
+++ b/src/versions/4.40.23081/nickel.yaml/pgaskin.yaml
@@ -15,7 +15,7 @@ Remove forgot pin button from lock screen:
       Removes the Forgot PIN -> Sign Out button from the lock screen.
       If this is enabled and you forget your pin, you will need to
       hard reset your Kobo.
-  - BaseAddress: 0x1C09CE3 # qss/PinCodeInputDialog.qss
+  - BaseAddress: 0x1C3E4E7 # qss/PinCodeInputDialog.qss
   - ReplaceZlib:
       Find: "#lblForgotPin[qApp_deviceIsDragon=true],\n#lblSignOut[qApp_deviceIsDragon=true] {\n  font-size: 26px;\n}"
       Replace: "#lblForgotPin,#lblSignOut{qproperty-visible:false;}"
@@ -23,7 +23,7 @@ Remove forgot pin button from lock screen:
 Increase size of kepub chapter progress chart:
   - Enabled: no
   - Description: Originally by oren64, rewritten for 4.16.13337 by pgaskin (geek1011).
-  - BaseAddress: 0x1C02490 # qss/ReadingMenuStatsView.qss
+  - BaseAddress: 0x1C20EAC # qss/ReadingMenuStatsView.qss
   - ReplaceZlibGroup:
       Replacements:
       # Top padding is already set to 15px, 25px, 33px, vertical aligned to middle.

--- a/src/versions/4.40.23081/nickel.yaml/pgaskin.yaml
+++ b/src/versions/4.40.23081/nickel.yaml/pgaskin.yaml
@@ -1,0 +1,54 @@
+# The following patch(es) are by pgaskin (geek1011)
+
+Show all games:
+  - Enabled: no
+  - Description: |
+      Shows all games in beta features. Since firmware 4.20.14601, this patch is
+      not needed if you have developer mode enabled (search
+      devmodeon/devmodeoff).
+  - FindZlib: "#boggleContainer[devModeOn=false][qApp_deviceIsPika=true]" # qss/N3SettingsExtrasView.qss
+  - ReplaceZlib: {Find: "qproperty-visible: false;", Replace: "qproperty-visible: true;"}
+
+Remove forgot pin button from lock screen:
+  - Enabled: no
+  - Description: |
+      Removes the Forgot PIN -> Sign Out button from the lock screen.
+      If this is enabled and you forget your pin, you will need to
+      hard reset your Kobo.
+  - BaseAddress: 0x1C09CE3 # qss/PinCodeInputDialog.qss
+  - ReplaceZlib:
+      Find: "#lblForgotPin[qApp_deviceIsDragon=true],\n#lblSignOut[qApp_deviceIsDragon=true] {\n  font-size: 26px;\n}"
+      Replace: "#lblForgotPin,#lblSignOut{qproperty-visible:false;}"
+
+Increase size of kepub chapter progress chart:
+  - Enabled: no
+  - Description: Originally by oren64, rewritten for 4.16.13337 by pgaskin (geek1011).
+  - BaseAddress: 0x1C02490 # qss/ReadingMenuStatsView.qss
+  - ReplaceZlibGroup:
+      Replacements:
+      # Top padding is already set to 15px, 25px, 33px, vertical aligned to middle.
+      # Progress chart bar sizes:
+      - Find:    "#chapterSizes[qApp_deviceIsTrilogy=true] {\n  max-height: 56px;\n  min-height: 56px;\n}"
+        Replace: "#chapterSizes[qApp_deviceIsTrilogy=true] {\n  max-height: 90px;\n  min-height: 90px;\n  min-width: 385px;\n  max-width: 385px;\n}"
+      - Find:    "#chapterSizes[qApp_deviceIsPhoenix=true] {\n  max-height: 70px;\n  min-height: 70px;\n}"
+        Replace: "#chapterSizes[qApp_deviceIsPhoenix=true] {\n  max-height: 130px;\n  min-height: 130px;\n  min-width: 495px;\n  max-width: 495px;\n}"
+      - Find:    "#chapterSizes[qApp_deviceIsDragon=true] {\n  max-height: 100px;\n  min-height: 100px;\n}"
+        Replace: "#chapterSizes[qApp_deviceIsDragon=true] {\n  max-height: 170px;\n  min-height: 170px;\n  min-width: 678px;\n  max-width: 678px;\n}"
+      - Find:    "#chapterSizes[qApp_deviceIsDaylight=true] {\n  max-height: 130px;\n  min-height: 130px;\n}"
+        Replace: "#chapterSizes[qApp_deviceIsDaylight=true] {\n  max-height: 215px;\n  min-height: 215px;\n  min-width: 865px;\n  max-width: 865px;\n}"
+
+Change TOC level indentation:
+  - Enabled: no
+  - Description: |
+      Changes the size of indentation for each level in the TOC. This patch
+      replaces the old "Increase TOC level indentation" patch from firmware
+      versions before 4.24.15672 (see the note in libnickel.so.1.0.0.yaml).
+  - FindZlib: "qproperty-indentUnit" # qss/N3TableOfContentsWidget.qss
+  - ReplaceZlibGroup:
+      Replacements:
+      # Change the replacement values to your desired width (I've made it half the default width as an example).
+      - {Find: "qproperty-indentUnit: 30;", Replace: "qproperty-indentUnit: 15;"} # trilogy
+      - {Find: "qproperty-indentUnit: 38;", Replace: "qproperty-indentUnit: 19;"} # phoenix
+      - {Find: "qproperty-indentUnit: 58;", Replace: "qproperty-indentUnit: 29;"} # dragon
+      - {Find: "qproperty-indentUnit: 72;", Replace: "qproperty-indentUnit: 36;"} # storm
+      - {Find: "qproperty-indentUnit: 76;", Replace: "qproperty-indentUnit: 38;"} # daylight


### PR DESCRIPTION
doing a brief update for the patches for 4.40 that released this month. still in progress but this is as far as i've gotten today. 

changes:
- allow info panel on random screensaver: FullScreenDragonPowerView -> BookCoverDragonPowerView
- don't uppercase header/footer: offset 282 -> 298
- don't uppercase header/footer + change page number text: offset 282 -> 298
- allow rotation on all devices: readingmenuview offset 236 -> 238
ETA: 
- customize comfort light settings: base address 0xE82E2C -> 0xE9841c
- remove forgot pin button: base address 0x1972E04 -> 0x1C3E4E7
- increase size of kepub chapter progress chart: base address 0x196E0F6  -> 0x1C20EAC

not tested/failed:
- my 24 line spacing
- remove pdf map widget